### PR TITLE
If the firmware is compiled as a slot#2 MPS link node, then the timin…

### DIFF
--- a/AmcCarrierCore/core/AmcCarrierCoreAdv.vhd
+++ b/AmcCarrierCore/core/AmcCarrierCoreAdv.vhd
@@ -233,6 +233,7 @@ begin
          BUILD_INFO_G     => BUILD_INFO_G,
          AXI_ERROR_RESP_G => AXI_ERROR_RESP_C,
          APP_TYPE_G       => APP_TYPE_G,
+         MPS_SLOT_G       => MPS_SLOT_G,
          FSBL_G           => false)
       port map (
          -- Primary AXI-Lite Interface

--- a/AmcCarrierCore/core/AmcCarrierCoreBase.vhd
+++ b/AmcCarrierCore/core/AmcCarrierCoreBase.vhd
@@ -861,6 +861,7 @@ begin
          BUILD_INFO_G     => BUILD_INFO_G,
          AXI_ERROR_RESP_G => AXI_ERROR_RESP_C,
          APP_TYPE_G       => APP_TYPE_G,
+         MPS_SLOT_G       => MPS_SLOT_G,
          FSBL_G           => false)
       port map (
          -- Primary AXI-Lite Interface

--- a/AmcCarrierCore/core/AmcCarrierSysReg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierSysReg.vhd
@@ -37,7 +37,7 @@ entity AmcCarrierSysReg is
       BUILD_INFO_G     : BuildInfoType;
       AXI_ERROR_RESP_G : slv(1 downto 0) := AXI_RESP_DECERR_C;
       APP_TYPE_G       : AppType         := APP_NULL_TYPE_C;
-      TIMING_MODE_G    : boolean         := false;  -- false = Normal Operation, = LCLS-I timing only
+      MPS_SLOT_G       : boolean         := false;  -- false = Normal Operation, true = MPS message concentrator (Slot#2 only)      
       FSBL_G           : boolean         := false);
    port (
       -- Primary AXI-Lite Interface
@@ -395,7 +395,7 @@ begin
       generic map (
          TPD_G            => TPD_G,
          AXI_ERROR_RESP_G => AXI_ERROR_RESP_G,
-         XBAR_DEFAULT_G   => xbarDefault(APP_TYPE_G, TIMING_MODE_G),
+         XBAR_DEFAULT_G   => xbarDefault(APP_TYPE_G, MPS_SLOT_G),
          AXI_CLK_FREQ_G   => AXI_CLK_FREQ_C)
       port map (
          -- XBAR Ports

--- a/AmcCarrierCore/core/AmcCarrierSysRegPkg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierSysRegPkg.vhd
@@ -2,7 +2,7 @@
 -- File       : AmcCarrierSysRegPkg.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-09-08
--- Last update: 2017-03-28
+-- Last update: 2017-04-26
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -65,30 +65,20 @@ package AmcCarrierSysRegPkg is
       1 => "01",   -- OUT[1] = IN[2], FPGA  = FPGA (loopback)
       0 => "00");  -- OUT[0] = IN[0], RTM0  = RTM0 (loopback)
 
-   function xbarDefault(app : AppType; sel : boolean) return Slv2Array;
+   function xbarDefault(app : AppType; mpsLinkNode : boolean) return Slv2Array;
 
 end package AmcCarrierSysRegPkg;
 
 package body AmcCarrierSysRegPkg is
 
-   function xbarDefault (app : AppType; sel : boolean) return Slv2Array is
+   function xbarDefault (app : AppType; mpsLinkNode : boolean) return Slv2Array is
       variable retVar : Slv2Array(3 downto 0);
    begin
-      -- Check for Timing Generator Node
       if (app = APP_TIME_GEN_TYPE_C) then
          retVar := XBAR_TIME_GEN_C;
-      -- Check for MPS Link Node
-      -- elsif (app = APP_MPS_LINK_AIN_TYPE_C) or (app = APP_MPS_LINK_DIN_TYPE_C) or (app = APP_MPS_LINK_MIXED_TYPE_C) then
-      --   retVar := XBAR_TIME_GEN_C;
-      -- -- Check for LCLS-I timing
-      -- if (sel = TIMING_MODE_119MHZ_C) then
-      -- retVar := XBAR_MPS_I_LINK_C;
-      -- -- Check for LCLS-II timing
-      -- else
-      -- retVar := XBAR_MPS_II_LINK_C;
-      -- end if;
+      elsif (mpsLinkNode = true) then
+         retVar := XBAR_MPS_II_LINK_C;
       else
-         -- Else Application Node
          retVar := XBAR_APP_NODE_C;
       end if;
       return retVar;


### PR DESCRIPTION
If the firmware is compiled as a slot#2 MPS link node, then the timing crossbar will boot up and be configured with the default MPS linknode timing crossbar configuration