### PR TITLE
Fixed incorrect clock definitions and -groups

### DIFF
--- a/AmcCarrierCore/xdc/AmcCarrierCoreTiming.xdc
+++ b/AmcCarrierCore/xdc/AmcCarrierCoreTiming.xdc
@@ -38,10 +38,10 @@ set_clock_groups -asynchronous -group [get_clocks {ddrClkIn}] -group [get_clocks
 ## Wrapper Timing Constraints ##
 ################################
 
-create_generate_clock -name iprogClk [get_pins {U_Core/U_SysReg/U_Iprog/GEN_ULTRA_SCALE.IprogUltraScale_Inst/BUFGCE_DIV_Inst/O}]]
-create_generate_clock -name dnaClk [get_pins {U_Core/U_SysReg/U_Version/GEN_DEVICE_DNA.DeviceDna_1/GEN_ULTRA_SCALE.DeviceDnaUltraScale_Inst/BUFGCE_DIV_Inst/O}]]
-set_clock_groups -asynchronous -group [get_clocks {axilClk}] -group [get_clocks {iprogClk}
-set_clock_groups -asynchronous -group [get_clocks {axilClk}] -group [get_clocks {dnaClk}
+create_generated_clock -name iprogClk -divide_by 8 -source [get_pins {U_Core/U_SysReg/U_Iprog/GEN_ULTRA_SCALE.IprogUltraScale_Inst/BUFGCE_DIV_Inst/I}] [get_pins {U_Core/U_SysReg/U_Iprog/GEN_ULTRA_SCALE.IprogUltraScale_Inst/BUFGCE_DIV_Inst/O}]
+create_generated_clock -name dnaClk -divide_by 8 -source [get_pins {U_Core/U_SysReg/U_Version/GEN_DEVICE_DNA.DeviceDna_1/GEN_ULTRA_SCALE.DeviceDnaUltraScale_Inst/BUFGCE_DIV_Inst/I}] [get_pins {U_Core/U_SysReg/U_Version/GEN_DEVICE_DNA.DeviceDna_1/GEN_ULTRA_SCALE.DeviceDnaUltraScale_Inst/BUFGCE_DIV_Inst/O}]
+set_clock_groups -asynchronous -group [get_clocks {axilClk}] -group [get_clocks {iprogClk}]
+set_clock_groups -asynchronous -group [get_clocks {axilClk}] -group [get_clocks {dnaClk}]
 
 create_generated_clock -name jesd0_185MHz [get_pins {U_AppTop/U_AmcBay[0].U_JesdCore/U_ClockManager/MmcmGen.U_Mmcm/CLKOUT0}]
 create_generated_clock -name jesd0_370MHz [get_pins {U_AppTop/U_AmcBay[0].U_JesdCore/U_ClockManager/MmcmGen.U_Mmcm/CLKOUT1}]


### PR DESCRIPTION
I looked at some critical warnings I got - apparently they have been there for a long time.

Some of the syntax and usage of commands related to the iprog and dna clocks were incorrect.

However, since the respective module does not actually use the generated clock (SLOW_CLOCK generic is set to true) the constraints could also be removed. I left them there so they are at least correct...