### PR TITLE
Connected AmcCarrierCoreAdv's 'timingTrig' port to AmcCarrierCore

### DIFF
--- a/AmcCarrierCore/core/AmcCarrierCoreAdv.vhd
+++ b/AmcCarrierCore/core/AmcCarrierCoreAdv.vhd
@@ -396,6 +396,7 @@ begin
          timingPhyRst         => timingPhyRst,
          timingRefClk         => timingRefClk,
          timingRefClkDiv2     => timingRefClkDiv2,
+         timingTrig           => timingTrig,
          -- Diagnostic Interface (diagnosticClk domain)
          diagnosticClk        => diagnosticClk,
          diagnosticRst        => diagnosticRst,


### PR DESCRIPTION
AmcCarrierCoreAdv's timingTrig port was dangling (not connected to AmcCarrierCore).