### PR TITLE
AppTop fails to connect outbound debug stream

### DIFF
--- a/AppTop/rtl/xcku040/AppTop.vhd
+++ b/AppTop/rtl/xcku040/AppTop.vhd
@@ -203,9 +203,6 @@ architecture mapping of AppTop is
    signal dacSigValids : Slv7Array(1 downto 0);
    signal dacSigValues : sampleDataVectorArray(1 downto 0, 6 downto 0);
 
-   signal obAppDbgMaster : AxiStreamMasterType;
-   signal obAppDbgSlave  : AxiStreamSlaveType;
-
 begin
 
    --------------------------
@@ -507,8 +504,8 @@ begin
          ibBpMsgServerMaster => ibBpMsgServerMaster,
          ibBpMsgServerSlave  => ibBpMsgServerSlave,
          -- Application Debug Interface (axilClk domain)
-         obAppDebugMaster    => obAppDbgMaster,
-         obAppDebugSlave     => obAppDbgSlave,
+         obAppDebugMaster    => obAppDebugMaster,
+         obAppDebugSlave     => obAppDebugSlave,
          ibAppDebugMaster    => ibAppDebugMaster,
          ibAppDebugSlave     => ibAppDebugSlave,
          -- MPS Concentrator Interface (axilClk domain)

--- a/AppTop/rtl/xcku040_mpsln/AppTop.vhd
+++ b/AppTop/rtl/xcku040_mpsln/AppTop.vhd
@@ -205,9 +205,6 @@ architecture mapping of AppTop is
    signal dacSigValids : Slv7Array(1 downto 0);
    signal dacSigValues : sampleDataVectorArray(1 downto 0, 6 downto 0);
 
-   signal obAppDbgMaster : AxiStreamMasterType;
-   signal obAppDbgSlave  : AxiStreamSlaveType;
-
    signal intRxP : Slv5Array(1 downto 0);
    signal intRxN : Slv5Array(1 downto 0);
    signal intTxP : Slv5Array(1 downto 0);
@@ -521,8 +518,8 @@ begin
          ibBpMsgServerMaster => ibBpMsgServerMaster,
          ibBpMsgServerSlave  => ibBpMsgServerSlave,
          -- Application Debug Interface (axilClk domain)
-         obAppDebugMaster    => obAppDbgMaster,
-         obAppDebugSlave     => obAppDbgSlave,
+         obAppDebugMaster    => obAppDebugMaster,
+         obAppDebugSlave     => obAppDebugSlave,
          ibAppDebugMaster    => ibAppDebugMaster,
          ibAppDebugSlave     => ibAppDebugSlave,
          -- MPS Concentrator Interface (axilClk domain)

--- a/AppTop/rtl/xcku060/AppTop.vhd
+++ b/AppTop/rtl/xcku060/AppTop.vhd
@@ -202,9 +202,6 @@ architecture mapping of AppTop is
    signal dacSigValids : Slv10Array(1 downto 0);
    signal dacSigValues : sampleDataVectorArray(1 downto 0, 9 downto 0);
 
-   signal obAppDbgMaster : AxiStreamMasterType;
-   signal obAppDbgSlave  : AxiStreamSlaveType;
-
 begin
 
    --------------------------
@@ -522,8 +519,8 @@ begin
          ibBpMsgServerMaster => ibBpMsgServerMaster,
          ibBpMsgServerSlave  => ibBpMsgServerSlave,
          -- Application Debug Interface (axilClk domain)
-         obAppDebugMaster    => obAppDbgMaster,
-         obAppDebugSlave     => obAppDbgSlave,
+         obAppDebugMaster    => obAppDebugMaster,
+         obAppDebugSlave     => obAppDebugSlave,
          ibAppDebugMaster    => ibAppDebugMaster,
          ibAppDebugSlave     => ibAppDebugSlave,
          -- MPS Concentrator Interface (axilClk domain)

--- a/AppTop/rtl/xcku11p/AppTop.vhd
+++ b/AppTop/rtl/xcku11p/AppTop.vhd
@@ -202,9 +202,6 @@ architecture mapping of AppTop is
    signal dacSigValids : Slv10Array(1 downto 0);
    signal dacSigValues : sampleDataVectorArray(1 downto 0, 9 downto 0);
 
-   signal obAppDbgMaster : AxiStreamMasterType;
-   signal obAppDbgSlave  : AxiStreamSlaveType;
-
 begin
 
    --------------------------
@@ -522,8 +519,8 @@ begin
          ibBpMsgServerMaster => ibBpMsgServerMaster,
          ibBpMsgServerSlave  => ibBpMsgServerSlave,
          -- Application Debug Interface (axilClk domain)
-         obAppDebugMaster    => obAppDbgMaster,
-         obAppDebugSlave     => obAppDbgSlave,
+         obAppDebugMaster    => obAppDebugMaster,
+         obAppDebugSlave     => obAppDebugSlave,
          ibAppDebugMaster    => ibAppDebugMaster,
          ibAppDebugSlave     => ibAppDebugSlave,
          -- MPS Concentrator Interface (axilClk domain)


### PR DESCRIPTION
The debug stream outbound from AppCore was connected to an intermediate signal which was otherwise unconnected thus rendering the outbound debug stream non-functional.