### PR TITLE
ESLCOMMON-234

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,3 +1,0 @@
-#Fetch LFS from github
-[lfs]
-  url = "git@github.com:slaclab/amc-carrier-core"


### PR DESCRIPTION
A while ago an '.lfsconfig' file was erroneously pushed. This was meant for local use only.