### PR TITLE
Cryo RTM - add timing trigger inputs to flux ramp reset

### DIFF
--- a/AppHardware/RtmCryoDet/rtl/RtmCryoDetReg.vhd
+++ b/AppHardware/RtmCryoDet/rtl/RtmCryoDetReg.vhd
@@ -34,7 +34,7 @@ entity RtmCryoDetReg is
       kRelay          : in  slv(1 downto 0);
       rampMaxCnt      : out slv(31 downto 0);
       enableRamp      : out sl;
-      rampStartMode   : out sl;
+      rampStartMode   : out slv(1 downto 0);
       selRamp         : out sl;
       pulseWidth      : out slv(15 downto 0);
       debounceWidth   : out slv(15 downto 0);
@@ -55,7 +55,7 @@ architecture rtl of RtmCryoDetReg is
       highCycle      : slv(CNT_WIDTH_G-1 downto 0);
       rampMaxCnt     : slv(31 downto 0);
       enableRamp     : sl;
-      rampStartMode  : sl;
+      rampStartMode  : slv(1 downto 0);
       selRamp        : sl;
       pulseWidth     : slv(15 downto 0);
       debounceWidth  : slv(15 downto 0);
@@ -69,7 +69,7 @@ architecture rtl of RtmCryoDetReg is
       highCycle      => toSlv(2, CNT_WIDTH_G),  -- 3 cycles low by default (zero inclusive)
       rampMaxCnt     => (others => '0'),
       enableRamp     => '0',
-      rampStartMode  => '0',
+      rampStartMode  => (others => '0'),
       selRamp        => '0',
       pulseWidth     => (others => '0'),
       debounceWidth  => (others => '0'),

--- a/python/AppHardware/RtmCryoDet/_rtmCryoDet.py
+++ b/python/AppHardware/RtmCryoDet/_rtmCryoDet.py
@@ -107,9 +107,9 @@ class RtmCryoDet(pr.Device):
 
         self.add(pr.RemoteVariable(    
             name         = "RampStartMode",
-            description  = "0x0 = internal start ramp pulses, 0x1 = external start ramp pulses",
+            description  = "0x0 = internal start ramp pulses, 0x1 = timing system trigger, 0x2 = external start ramp pulses",
             offset       = 0x14,
-            bitSize      = 1,
+            bitSize      = 2,
             bitOffset    = 2,
             base         = pr.UInt,
             mode         = "RW",


### PR DESCRIPTION
Cryo RTM.  Add timing trigger input to flux ramp reset.  Update registers to allow flux ramp reset to be one of:
0x0 -> Internally generated trigger
0x1 -> Timing trigger
0x2 -> External trigger 