### PR TITLE
Fix shadow register for hmc305, should hold 8 values.  

### DIFF
--- a/AppHardware/AmcMicrowaveMux/rtl/hmc305.vhd
+++ b/AppHardware/AmcMicrowaveMux/rtl/hmc305.vhd
@@ -57,7 +57,7 @@ architecture rtl of hmc305 is
 
    type RegType is record
       cnt           : natural range 0 to MAX_CNT_C;
-      data          : Slv5Array(2 downto 0);
+      data          : Slv5Array(7 downto 0);
       devAddr       : slv(2 downto 0);
       devLe         : sl;
       wrEn          : sl;

--- a/python/AppHardware/AmcMicrowaveMux/_hmc305.py
+++ b/python/AppHardware/AmcMicrowaveMux/_hmc305.py
@@ -44,7 +44,7 @@ class Hmc305(pr.Device):
                 description = 'Hmc305 Device: Note that firmware does an invert and bit order swap to make the software interface with a LSB of 0.5dB',
                 offset      = devConfig[i][1], 
                 bitSize     = 5, 
-                mode        = 'WO',
+                mode        = 'RW',
                 units       = '0.5dB',
             ))
             


### PR DESCRIPTION
Fix shadow register for hmc305, should hold 8 values.  
Update pyrogue registers RW  to match the shadow registers.