### PR TITLE
Update HMC305 bootup values

### DIFF
--- a/AppHardware/AmcMicrowaveMux/rtl/hmc305.vhd
+++ b/AppHardware/AmcMicrowaveMux/rtl/hmc305.vhd
@@ -69,7 +69,7 @@ architecture rtl of hmc305 is
 
    constant REG_INIT_C : RegType := (
       cnt           => 0,
-      data          => (others => (others => '0')),
+      data          => (others => (others => '1')),
       devAddr       => (others => '0'),
       devLe         => '0',
       wrEn          => '0',


### PR DESCRIPTION
Update REG_INIT_C data to match hardware bootup - attenuators power up at 0x1F.  This fixes inconsistency with readback after power up.