### PR TITLE
Change app types and allow different mps message size for lcls1

### DIFF
--- a/AmcCarrierCore/core/AmcCarrierPkg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierPkg.vhd
@@ -99,8 +99,8 @@ package AmcCarrierPkg is
    constant APP_BPM_STRIPLINE_TYPE_C : AppType := toSlv(100, AppType'length);
    constant APP_BPM_CAVITY_TYPE_C    : AppType := toSlv(101, AppType'length);
 
-   constant APP_MPS_24CH_TYPE_C : AppType := toSlv(120, AppType'length);
-   constant APP_MPS_6CH_TYPE_C  : AppType := toSlv(121, AppType'length);
+   constant APP_MPS_AN_TYPE_C : AppType := toSlv(120, AppType'length);
+   constant APP_MPS_LN_TYPE_C : AppType := toSlv(121, AppType'length);
 
    -------------------------------------
    -- Common Platform: General Constants

--- a/AppMps/rtl/AppMpsEncoder.vhd
+++ b/AppMps/rtl/AppMpsEncoder.vhd
@@ -184,12 +184,17 @@ begin
       v := r;
 
       -- Init and setup MPS message
-      v.mpsMessage           := mpsMessageInit(APP_CONFIG_C.BYTE_COUNT_C);
       v.mpsMessage.version   := mpsReg.mpsCore.mpsVersion;
       v.mpsMessage.lcls      := mpsReg.mpsCore.lcls1Mode;
       v.mpsMessage.timeStamp := mpsSelect.timeStamp;
       v.mpsMessage.appId     := resize(mpsReg.mpsCore.mpsAppId, 16);
       v.mpsMessage.valid     := mpsSelect.valid and mpsReg.mpsCore.mpsEnable;
+
+      if mpsReg.mpsCore.lcls1Mode = '1' then
+         v.mpsMessage := mpsMessageInit(APP_CONFIG_C.LCLS1_COUNT_C);
+      else 
+         v.mpsMessage := mpsMessageInit(APP_CONFIG_C.LCLS2_COUNT_C);
+      end if;
 
       -- Init message data
       msgData := (others => (others => '0'));

--- a/AppMps/rtl/AppMpsEncoder.vhd
+++ b/AppMps/rtl/AppMpsEncoder.vhd
@@ -236,14 +236,14 @@ begin
                elsif APP_CONFIG_C.CHAN_CONFIG_C(chan).LCLS1_EN_C and mpsReg.mpsCore.lcls1Mode = '1' then
                   compareTholds (mpsReg.mpsChanReg(chan).lcls1Thold,
                                  APP_CONFIG_C.CHAN_CONFIG_C(chan),
-                                 mpsSelect.chanData(chan), mpsSelect.mpsIgnore(chan), mpsSelect.valid, 1,
+                                 mpsSelect.chanData(chan), mpsSelect.mpsIgnore(chan), mpsSelect.valid, '1',
                                  0, r.tholdMem(chan, 0), v.tholdMem(chan, 0), msgData);
 
                -- LCLS2 idle table
                elsif APP_CONFIG_C.CHAN_CONFIG_C(chan).IDLE_EN_C and mpsReg.mpsChanReg(chan).idleEn = '1' and mpsSelect.selectIdle = '1' then
                   compareTholds (mpsReg.mpsChanReg(chan).idleThold,
                                  APP_CONFIG_C.CHAN_CONFIG_C(chan),
-                                 mpsSelect.chanData(chan), mpsSelect.mpsIgnore(chan), mpsSelect.valid, 0,
+                                 mpsSelect.chanData(chan), mpsSelect.mpsIgnore(chan), mpsSelect.valid, '0',
                                  7, r.tholdMem(chan, 7), v.tholdMem(chan, 7), msgData);
 
                -- Multiple thresholds
@@ -254,14 +254,14 @@ begin
                      if APP_CONFIG_C.CHAN_CONFIG_C(chan).ALT_EN_C and mpsSelect.selectAlt = '1' then
                         compareTholds (mpsReg.mpsChanReg(chan).altTholds(thold),
                                        APP_CONFIG_C.CHAN_CONFIG_C(chan),
-                                       mpsSelect.chanData(chan), mpsSelect.mpsIgnore(chan), mpsSelect.valid, 0,
+                                       mpsSelect.chanData(chan), mpsSelect.mpsIgnore(chan), mpsSelect.valid, '0',
                                        thold, r.tholdMem(chan, thold), v.tholdMem(chan, thold), msgData);
 
                      -- Standard table
                      else
                         compareTholds (mpsReg.mpsChanReg(chan).stdTholds(thold),
                                        APP_CONFIG_C.CHAN_CONFIG_C(chan),
-                                       mpsSelect.chanData(chan), mpsSelect.mpsIgnore(chan), mpsSelect.valid, 0,
+                                       mpsSelect.chanData(chan), mpsSelect.mpsIgnore(chan), mpsSelect.valid, '0',
                                        thold, r.tholdMem(chan, thold), v.tholdMem(chan, thold), msgData);
                      end if;
                   end loop;

--- a/AppMps/rtl/AppMpsEncoder.vhd
+++ b/AppMps/rtl/AppMpsEncoder.vhd
@@ -93,13 +93,13 @@ architecture mapping of AppMpsEncoder is
       if ignore = '0' and ((thold.maxTholdEn = '1' and signedVal > signedMax) or
                            (thold.minTholdEn = '1' and signedVal < signedMin)) then
 
-         tholdMemOut := (others => '1');
-
          if holdDisable = '1' then
-            message(config.BYTE_MAP_C)(bitPos) := '0';
+            tholdMemOut := (others => '0');
          else
-            message(config.BYTE_MAP_C)(bitPos) := '1';
+            tholdMemOut := (others => '1');
          end if;
+
+         message(config.BYTE_MAP_C)(bitPos) := '1';
 
       -- Threhold was exceeded within the last 15 clocks
       elsif tholdMemIn /= 0 then

--- a/AppMps/rtl/AppMpsEncoder.vhd
+++ b/AppMps/rtl/AppMpsEncoder.vhd
@@ -183,18 +183,18 @@ begin
       -- Latch the current value
       v := r;
 
+      if mpsReg.mpsCore.lcls1Mode = '1' then
+         v.mpsMessage := mpsMessageInit(APP_CONFIG_C.LCLS1_COUNT_C);
+      else 
+         v.mpsMessage := mpsMessageInit(APP_CONFIG_C.LCLS2_COUNT_C);
+      end if;
+
       -- Init and setup MPS message
       v.mpsMessage.version   := mpsReg.mpsCore.mpsVersion;
       v.mpsMessage.lcls      := mpsReg.mpsCore.lcls1Mode;
       v.mpsMessage.timeStamp := mpsSelect.timeStamp;
       v.mpsMessage.appId     := resize(mpsReg.mpsCore.mpsAppId, 16);
       v.mpsMessage.valid     := mpsSelect.valid and mpsReg.mpsCore.mpsEnable;
-
-      if mpsReg.mpsCore.lcls1Mode = '1' then
-         v.mpsMessage := mpsMessageInit(APP_CONFIG_C.LCLS1_COUNT_C);
-      else 
-         v.mpsMessage := mpsMessageInit(APP_CONFIG_C.LCLS2_COUNT_C);
-      end if;
 
       -- Init message data
       msgData := (others => (others => '0'));

--- a/AppMps/rtl/AppMpsPkg.vhd
+++ b/AppMps/rtl/AppMpsPkg.vhd
@@ -435,7 +435,7 @@ package body AppMpsPkg is
             ret.DIGITAL_EN_C := true;
             ret.BYTE_COUNT_C := 1;
 
-         when APP_MPS_LN_TYPE_C | APP_MPS_LN_TYPE_C =>
+         when APP_MPS_AN_TYPE_C | APP_MPS_LN_TYPE_C =>
             ret.BYTE_COUNT_C  := 12;
             ret.LCLS1_COUNT_C := 12;
             ret.LCLS2_COUNT_C := 6;

--- a/AppMps/rtl/AppMpsPkg.vhd
+++ b/AppMps/rtl/AppMpsPkg.vhd
@@ -113,13 +113,17 @@ package AppMpsPkg is
    ---------------------------------------------------   
    type MpsAppConfigType is record
       DIGITAL_EN_C  : boolean;          -- APP is digital
-      BYTE_COUNT_C  : integer range 0 to MPS_CHAN_COUNT_C;  -- MPS message bytes
+      BYTE_COUNT_C  : integer range 0 to MPS_CHAN_COUNT_C;  -- MPS message bytes max
+      LCLS1_COUNT_C : integer range 0 to MPS_CHAN_COUNT_C;  -- MPS message bytes for LCLS1
+      LCLS2_COUNT_C : integer range 0 to MPS_CHAN_COUNT_C;  -- MPS message bytes for LCLS1
       CHAN_CONFIG_C : MpsChanConfigArray(MPS_CHAN_COUNT_C-1 downto 0);
    end record;
 
    constant MPS_APP_CONFIG_INIT_C : MpsAppConfigType := (
       DIGITAL_EN_C  => false,
       BYTE_COUNT_C  => 0,
+      LCLS1_COUNT_C => 0,
+      LCLS2_COUNT_C => 0,
       CHAN_CONFIG_C => (others => MPS_CHAN_CONFIG_INIT_C));
 
    ---------------------------------------------------
@@ -360,7 +364,9 @@ package body AppMpsPkg is
 
       case app is
          when APP_BPM_STRIPLINE_TYPE_C | APP_BPM_CAVITY_TYPE_C =>
-            ret.BYTE_COUNT_C := 6;
+            ret.BYTE_COUNT_C  := 6;
+            ret.LCLS1_COUNT_C := 6;
+            ret.LCLS2_COUNT_C := 6;
 
             for i in 0 to 1 loop
 
@@ -388,7 +394,8 @@ package body AppMpsPkg is
             end loop;
 
          when APP_BLEN_TYPE_C =>
-            ret.BYTE_COUNT_C := 2;
+            ret.BYTE_COUNT_C  := 2;
+            ret.LCLS2_COUNT_C := 2;
 
             -- Input 0
             ret.CHAN_CONFIG_C(0).THOLD_COUNT_C := 4;
@@ -401,7 +408,8 @@ package body AppMpsPkg is
             ret.CHAN_CONFIG_C(16).BYTE_MAP_C    := 1;
 
          when APP_BCM_TYPE_C =>
-            ret.BYTE_COUNT_C := 4;
+            ret.BYTE_COUNT_C  := 4;
+            ret.LCLS2_COUNT_C := 4;
 
             -- Input 0
             ret.CHAN_CONFIG_C(0).THOLD_COUNT_C := 4;
@@ -427,25 +435,21 @@ package body AppMpsPkg is
             ret.DIGITAL_EN_C := true;
             ret.BYTE_COUNT_C := 1;
 
-         when APP_MPS_24CH_TYPE_C =>
-            ret.BYTE_COUNT_C := 24;
+         when APP_MPS_LN_TYPE_C | APP_MPS_LN_TYPE_C =>
+            ret.BYTE_COUNT_C  := 12;
+            ret.LCLS1_COUNT_C := 12;
+            ret.LCLS2_COUNT_C := 6;
 
-            for i in 0 to 23 loop
+            for i in 0 to 11 loop
                ret.CHAN_CONFIG_C(i).THOLD_COUNT_C := 7;
                ret.CHAN_CONFIG_C(i).LCLS1_EN_C    := true;
                ret.CHAN_CONFIG_C(i).BYTE_MAP_C    := i;
                ret.CHAN_CONFIG_C(i).IDLE_EN_C     := true;
             end loop;
 
-         when APP_MPS_6CH_TYPE_C =>
-            ret.BYTE_COUNT_C := 6;
-
-            for i in 0 to 5 loop
-               ret.CHAN_CONFIG_C(i).THOLD_COUNT_C := 7;
-               ret.CHAN_CONFIG_C(i).LCLS1_EN_C    := true;
-               ret.CHAN_CONFIG_C(i).BYTE_MAP_C    := i;
-               ret.CHAN_CONFIG_C(i).IDLE_EN_C     := true;
-            end loop;
+         while APP_FWS_TYPE_C =>
+            ret.DIGITAL_EN_C := true;
+            ret.BYTE_COUNT_C := 1;
 
         when others =>
             NULL;

--- a/AppMps/rtl/AppMpsPkg.vhd
+++ b/AppMps/rtl/AppMpsPkg.vhd
@@ -447,7 +447,7 @@ package body AppMpsPkg is
                ret.CHAN_CONFIG_C(i).IDLE_EN_C     := true;
             end loop;
 
-         while APP_FWS_TYPE_C =>
+         when APP_FWS_TYPE_C =>
             ret.DIGITAL_EN_C := true;
             ret.BYTE_COUNT_C := 1;
 

--- a/AppMps/rtl/AppMpsRegBase.vhd
+++ b/AppMps/rtl/AppMpsRegBase.vhd
@@ -111,6 +111,8 @@ begin
 
       axiSlaveRegisterR(regEp, x"0004", 0, toSlv(APP_CONFIG_G.BYTE_COUNT_C, 8));
       axiSlaveRegisterR(regEp, x"0004", 8, ite(APP_CONFIG_G.DIGITAL_EN_C, '1', '0'));
+      axiSlaveRegisterR(regEp, x"0004", 16, toSlv(APP_CONFIG_G.LCLS2_COUNT_C, 8));
+      axiSlaveRegisterR(regEp, x"0004", 24, toSlv(APP_CONFIG_G.LCLS1_COUNT_C, 8));
 
       axiSlaveRegister(regEp, x"0008", 0, v.beamDestMask);
       axiSlaveRegister(regEp, x"0008", 16, v.altDestMask);

--- a/AppMps/yaml/AppMpsRegBase.yaml
+++ b/AppMps/yaml/AppMpsRegBase.yaml
@@ -64,6 +64,22 @@ AppMpsRegBase: &AppMpsRegBase
       lsBit:        0
       mode:         RO
       description:  Application generates digital message
+    lcls2Count:
+      at:
+        offset:     0x06
+      class:        IntField
+      sizeBits:     8
+      lsBit:        0
+      mode:         RO
+      description:  Number of bytes in LCLS2 MPS message
+    lcls1Count:
+      at:
+        offset:     0x07
+      class:        IntField
+      sizeBits:     8
+      lsBit:        0
+      mode:         RO
+      description:  Number of bytes in LCLS1 MPS message
     beamDestMask:
       at:
         offset:     0x08


### PR DESCRIPTION
This PR does the following.

1. Add MPS support for the fast wire scanner.

2. Remove the different link node types and replace with link node and application node types.

3. Allow LCLS1 and LCLS2 modes to generate different size MPS messages.