### PR TITLE
Adding WAVEFORM_NUM_LANES_G support

### DIFF
--- a/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
@@ -2,7 +2,7 @@
 -- File       : AmcCarrierCore.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-07-08
--- Last update: 2018-08-28
+-- Last update: 2019-09-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -33,7 +33,8 @@ entity AmcCarrierCore is
    generic (
       TPD_G                  : time     := 1 ns;
       ETH_USR_FRAME_LIMIT_G  : positive := 4096;   -- 4kB   
-      WAVEFORM_TDATA_BYTES_G : positive := 4;
+      WAVEFORM_NUM_LANES_G   : positive := 4;  -- Number of Waveform lanes per DaqMuxV2
+      WAVEFORM_TDATA_BYTES_G : positive := 4;  -- Waveform stream's tData width (in units of bytes)
       RSSI_ILEAVE_EN_G       : boolean  := false;
       SIM_SPEEDUP_G          : boolean  := false;  -- false = Normal Operation, true = simulation
       DISABLE_BSA_G          : boolean  := false;  -- false = includes BSA engine, true = doesn't build the BSA engine
@@ -420,6 +421,7 @@ begin
          DISABLE_BSA_G          => DISABLE_BSA_G,
          DISABLE_BLD_G          => DISABLE_BLD_G,
          DISABLE_DDR_SRP_G      => DISABLE_DDR_SRP_G,
+         WAVEFORM_NUM_LANES_G   => WAVEFORM_NUM_LANES_G,
          WAVEFORM_TDATA_BYTES_G => WAVEFORM_TDATA_BYTES_G)
       port map (
          -- AXI-Lite Interface (axilClk domain)

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCoreAdv.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCoreAdv.vhd
@@ -46,7 +46,8 @@ entity AmcCarrierCoreAdv is
       TRIG_PIPE_G            : natural  := 0;  -- no trigger pipeline by default
       FSBL_G                 : boolean  := false;  -- false = Normal Operation, true = First Stage Boot loader
       APP_TYPE_G             : AppType;
-      WAVEFORM_TDATA_BYTES_G : positive := 4;
+      WAVEFORM_NUM_LANES_G   : positive := 4;  -- Number of Waveform lanes per DaqMuxV2
+      WAVEFORM_TDATA_BYTES_G : positive := 4;  -- Waveform stream's tData width (in units of bytes)
       ETH_USR_FRAME_LIMIT_G  : positive := 4096;   -- 4kB  
       MPS_SLOT_G             : boolean  := false);  -- false = Normal Operation, true = MPS message concentrator (Slot#2 only)      
    port (
@@ -392,6 +393,7 @@ begin
    U_Core : entity work.AmcCarrierCore
       generic map (
          TPD_G                  => TPD_G,
+         WAVEFORM_NUM_LANES_G   => WAVEFORM_NUM_LANES_G,
          WAVEFORM_TDATA_BYTES_G => WAVEFORM_TDATA_BYTES_G,
          ETH_USR_FRAME_LIMIT_G  => ETH_USR_FRAME_LIMIT_G,
          RSSI_ILEAVE_EN_G       => RSSI_ILEAVE_EN_G,

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCoreBase.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCoreBase.vhd
@@ -46,7 +46,8 @@ entity AmcCarrierCoreBase is
       TRIG_PIPE_G            : natural  := 0;  -- no trigger pipeline by default
       FSBL_G                 : boolean  := false;  -- false = Normal Operation, true = First Stage Boot loader
       APP_TYPE_G             : AppType;
-      WAVEFORM_TDATA_BYTES_G : positive := 4;
+      WAVEFORM_NUM_LANES_G   : positive := 4;  -- Number of Waveform lanes per DaqMuxV2
+      WAVEFORM_TDATA_BYTES_G : positive := 4;  -- Waveform stream's tData width (in units of bytes)
       ETH_USR_FRAME_LIMIT_G  : positive := 4096;   -- 4kB  
       MPS_SLOT_G             : boolean  := false);  -- false = Normal Operation, true = MPS message concentrator (Slot#2 only)      
    port (
@@ -392,6 +393,7 @@ begin
    U_Core : entity work.AmcCarrierCore
       generic map (
          TPD_G                  => TPD_G,
+         WAVEFORM_NUM_LANES_G   => WAVEFORM_NUM_LANES_G,
          WAVEFORM_TDATA_BYTES_G => WAVEFORM_TDATA_BYTES_G,
          ETH_USR_FRAME_LIMIT_G  => ETH_USR_FRAME_LIMIT_G,
          RSSI_ILEAVE_EN_G       => RSSI_ILEAVE_EN_G,

--- a/AppTop/rtl/xcku11p/AppTop.vhd
+++ b/AppTop/rtl/xcku11p/AppTop.vhd
@@ -84,9 +84,9 @@ entity AppTop is
       waveformClk          : in    sl;
       waveformRst          : in    sl;
       obAppWaveformMasters : out   WaveformMasterArrayType := (others=>(others=>AXI_STREAM_MASTER_INIT_C));
-      obAppWaveformSlaves  : in    WaveformSlaveArrayType  := (others=>WAVEFORM_SLAVE_REC_FORCE_C);
+      obAppWaveformSlaves  : in    WaveformSlaveArrayType  := (others=>(others=>WAVEFORM_SLAVE_REC_FORCE_C));
       ibAppWaveformMasters : in    WaveformMasterArrayType := (others=>(others=>AXI_STREAM_MASTER_INIT_C));
-      ibAppWaveformSlaves  : out   WaveformSlaveArrayType  := (others=>WAVEFORM_SLAVE_REC_FORCE_C);
+      ibAppWaveformSlaves  : out   WaveformSlaveArrayType  := (others=>(others=>WAVEFORM_SLAVE_REC_FORCE_C));
       -- Backplane Messaging Interface  (axilClk domain)
       obBpMsgClientMaster  : out   AxiStreamMasterType;
       obBpMsgClientSlave   : in    AxiStreamSlaveType;
@@ -203,9 +203,9 @@ architecture mapping of AppTop is
    signal dacSigValids : Slv10Array(1 downto 0);
    signal dacSigValues : sampleDataVectorArray(1 downto 0, 9 downto 0);
    
-   type WaveMasterArray is array (natural range <>) of AxiStreamCtrlArray(WAVEFORM_NUM_LANES_G-1 downto 0 downto 0);   
-   type WaveSlaveArray is array (natural range <>) of AxiStreamCtrlArray(WAVEFORM_NUM_LANES_G-1 downto 0 downto 0);   
-   type WaveCtrlArray is array (natural range <>) of AxiStreamCtrlArray(WAVEFORM_NUM_LANES_G-1 downto 0 downto 0);   
+   type WaveMasterArray is array (natural range <>) of AxiStreamMasterArray(WAVEFORM_NUM_LANES_G-1 downto 0);   
+   type WaveSlaveArray is array (natural range <>) of AxiStreamSlaveArray(WAVEFORM_NUM_LANES_G-1 downto 0);   
+   type WaveCtrlArray is array (natural range <>) of AxiStreamCtrlArray(WAVEFORM_NUM_LANES_G-1 downto 0);   
    
    signal waveAxisMasterArr : WaveMasterArray(1 downto 0);
    signal waveAxisSlaveArr  : WaveSlaveArray(1 downto 0);

--- a/BsaCore/rtl/BsaWaveformEngine.vhd
+++ b/BsaCore/rtl/BsaWaveformEngine.vhd
@@ -29,6 +29,7 @@ entity BsaWaveformEngine is
 
    generic (
       TPD_G                  : time                   := 1 ns;
+      WAVEFORM_NUM_LANES_G   : positive range 1 to 4  := 4;
       WAVEFORM_TDATA_BYTES_G : positive range 4 to 16 := 4;
       AXIL_BASE_ADDR_G       : slv(31 downto 0)       := (others => '0');
       AXI_CONFIG_G           : AxiConfigType          := axiConfig(33, 16, 1, 8));
@@ -37,7 +38,7 @@ entity BsaWaveformEngine is
       waveformClk : in sl;
       waveformRst : in sl;
       ibWaveformMasters : in  WaveformMasterType;
-      ibWaveformSlaves  : out WaveformSlaveType;
+      ibWaveformSlaves  : out WaveformSlaveType := (others=>WAVEFORM_SLAVE_REC_FORCE_C);
       -- AXI-Lite configuration interface
       axilClk           : in  sl;
       axilRst           : in  sl;
@@ -72,7 +73,8 @@ architecture rtl of BsaWaveformEngine is
    constant WAVEFORM_AXIS_CONFIG_C : AxiStreamConfigType :=
       ssiAxiStreamConfig(WAVEFORM_TDATA_BYTES_G, TKEEP_FIXED_C, TUSER_FIRST_LAST_C, 0, 3);  -- No tdest bits, 3 tUser bits
 
-   constant STREAMS_C : integer := WaveformMasterType'length;
+   -- constant STREAMS_C : positive := WaveformMasterType'length;
+   constant STREAMS_C : positive := WAVEFORM_NUM_LANES_G;
 
    constant TDEST_ROUTES_C : Slv8Array(STREAMS_C-1 downto 0) := (others => "--------");
 
@@ -82,7 +84,7 @@ architecture rtl of BsaWaveformEngine is
    constant WRITE_AXIS_CONFIG_C : AxiStreamConfigType := (
       TSTRB_EN_C    => false,
       TDATA_BYTES_C => AXI_CONFIG_G.DATA_BYTES_C,
-      TDEST_BITS_C  => log2(STREAMS_C),
+      TDEST_BITS_C  => bitSize(STREAMS_C-1),
       TID_BITS_C    => 0,
       TKEEP_MODE_C  => TKEEP_FIXED_C,
       TUSER_BITS_C  => 3,
@@ -118,7 +120,7 @@ architecture rtl of BsaWaveformEngine is
    constant READ_AXIS_CONFIG_C : AxiStreamConfigType := (
       TSTRB_EN_C    => false,
       TDATA_BYTES_C => AXI_CONFIG_G.DATA_BYTES_C,
-      TDEST_BITS_C  => log2(STREAMS_C),
+      TDEST_BITS_C  => bitSize(STREAMS_C-1),
       TID_BITS_C    => 0,
       TKEEP_MODE_C  => TKEEP_FIXED_C,
       TUSER_BITS_C  => 2,

--- a/DaqMuxV2/rtl/DaqRegItf.vhd
+++ b/DaqMuxV2/rtl/DaqRegItf.vhd
@@ -31,7 +31,7 @@ entity DaqRegItf is
       TPD_G            : time     := 1 ns;
       AXI_ADDR_WIDTH_G : positive := 10;
       N_DATA_IN_G      : positive := 16;
-      N_DATA_OUT_G     : positive := 8
+      N_DATA_OUT_G     : positive := 4
       );
    port (
       -- Axi-Lite Clk

--- a/DaqMuxV2/rtl/DaqRegItf.vhd
+++ b/DaqMuxV2/rtl/DaqRegItf.vhd
@@ -243,6 +243,11 @@ begin
                v.axilReadSlave.rdata(N_DATA_IN_G-1 downto 0) := s_sampleValid;
             when 16#0c# =>              -- ADDR (0x30)
                v.axilReadSlave.rdata(N_DATA_IN_G-1 downto 0) := s_linkReady;
+            when 16#0d# =>              -- ADDR (0x34)
+               v.axilReadSlave.rdata(7 downto 0)   := toSlv(AXI_ADDR_WIDTH_G,8);
+               v.axilReadSlave.rdata(15 downto 8)  := toSlv(N_DATA_IN_G,8);
+               v.axilReadSlave.rdata(23 downto 16) := toSlv(N_DATA_OUT_G,8);
+               v.axilReadSlave.rdata(31 downto 24) := x"00";               
             when 16#10# to 16#1F# =>    -- ADDR (0x40)
                for I in (N_DATA_OUT_G-1) downto 0 loop
                   if (axilReadMaster.araddr(5 downto 2) = I) then

--- a/python/AmcCarrierCore/AmcCarrierBsa.py
+++ b/python/AmcCarrierCore/AmcCarrierBsa.py
@@ -25,6 +25,7 @@ class AmcCarrierBsa(pr.Device):
             name        = "AmcCarrierBsa", 
             description = "AmcCarrier BSA Module", 
             enableBsa   = True,
+            numWaveformBuffers  = 4,
             **kwargs):
         super().__init__(name=name, description=description, **kwargs)
         
@@ -39,6 +40,7 @@ class AmcCarrierBsa(pr.Device):
 
         for i in range(2):
             self.add(bsa.BsaWaveformEngine(
-                name   = f'BsaWaveformEngine[{i}]',
-                offset =  0x00010000 + i * 0x00010000,
+                name       = f'BsaWaveformEngine[{i}]',
+                offset     =  0x00010000 + i * 0x00010000,
+                numBuffers = numWaveformBuffers,
             ))

--- a/python/AmcCarrierCore/AmcCarrierCore.py
+++ b/python/AmcCarrierCore/AmcCarrierCore.py
@@ -24,6 +24,7 @@ class AmcCarrierCore(pr.Device):
             enableBsa           = True,
             enableMps           = True,
             expand	            = False,
+            numWaveformBuffers  = 4,
             **kwargs):
         super().__init__(name=name, description=description, expand=expand, **kwargs)  
 
@@ -94,9 +95,10 @@ class AmcCarrierCore(pr.Device):
         ))
 
         self.add(amcc.AmcCarrierBsa(   
-            offset       =  0x09000000, 
-            enableBsa    =  enableBsa,
-            expand       =  False,
+            offset             =  0x09000000, 
+            enableBsa          =  enableBsa,
+            numWaveformBuffers =  numWaveformBuffers,
+            expand             =  False,
         ))
                             
         self.add(udp.UdpEngineClient(

--- a/python/AppTop/AppTop.py
+++ b/python/AppTop/AppTop.py
@@ -38,6 +38,7 @@ class AppTop(pr.Device):
             numSigGen      = [0,0],
             sizeSigGen     = [0,0],
             modeSigGen     = [False,False],
+            numWaveformBuffers  = 4,
             **kwargs):
         super().__init__(name=name, description=description, **kwargs)
         
@@ -59,9 +60,10 @@ class AppTop(pr.Device):
 
         for i in range(2):
             self.add(daqMuxV2.DaqMuxV2(
-                name         = f'DaqMuxV2[{i}]',
-                offset       =  0x20000000 + (i * 0x10000000),
-                expand       =  False,
+                name       = f'DaqMuxV2[{i}]',
+                offset     =  0x20000000 + (i * 0x10000000),
+                numBuffers =  numWaveformBuffers,
+                expand     =  False,
             ))
 
         for i in range(2):

--- a/python/AppTop/TopLevel.py
+++ b/python/AppTop/TopLevel.py
@@ -47,6 +47,7 @@ class TopLevel(pr.Device):
             # General Parameters
             enableBsa       = False,
             enableMps       = False,
+            numWaveformBuffers  = 4,
             **kwargs):
         super().__init__(name=name, description=description, **kwargs)
 
@@ -140,6 +141,7 @@ class TopLevel(pr.Device):
             rssiNotInterlaved = rssiNotInterlaved,
             enableBsa         = enableBsa,
             enableMps         = enableMps,
+            numWaveformBuffers= numWaveformBuffers,
         ))
         self.add(appTop.AppTop(
             memBase      = self.srp,
@@ -150,6 +152,7 @@ class TopLevel(pr.Device):
             numSigGen    = numSigGen,
             sizeSigGen   = sizeSigGen,
             modeSigGen   = modeSigGen,
+            numWaveformBuffers = numWaveformBuffers,
         ))
 
         # Define SW trigger command

--- a/python/BsaCore/BsaWaveformEngine.py
+++ b/python/BsaCore/BsaWaveformEngine.py
@@ -24,10 +24,13 @@ class BsaWaveformEngine(pr.Device):
     def __init__(   self, 
             name        = "BsaWaveformEngine", 
             description = "Configuration and status of the BSA dignosic buffers", 
+            numBuffers  = 4,
             **kwargs):
         super().__init__(name=name, description=description, **kwargs)
 
         self.add(axi.AxiStreamDmaRingWrite(
-            offset =  0x00000000,
-            name   = "WaveformEngineBuffers",
+            name       = "WaveformEngineBuffers",
+            offset     = 0x00000000,
+            numBuffers = numBuffers,
         ))
+        

--- a/python/DaqMuxV2/DaqMuxV2.py
+++ b/python/DaqMuxV2/DaqMuxV2.py
@@ -37,7 +37,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x00,
             bitSize      =  1,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RW",
         ))
 
@@ -73,7 +72,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x00,
             bitSize      =  1,
             bitOffset    =  0x03,
-            base         = pr.UInt,
             mode         = "RW",
         ))
 
@@ -83,7 +81,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x00,
             bitSize      =  1,
             bitOffset    =  0x04,
-            base         = pr.UInt,
             mode         = "RW",
         ))
 
@@ -119,7 +116,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x00,
             bitSize      =  1,
             bitOffset    =  0x07,
-            base         = pr.UInt,
             mode         = "RW",
         ))
 
@@ -142,7 +138,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x04,
             bitSize      =  1,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
         ))
@@ -153,7 +148,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x04,
             bitSize      =  1,
             bitOffset    =  0x01,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
         ))
@@ -164,7 +158,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x04,
             bitSize      =  1,
             bitOffset    =  0x02,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
         ))
@@ -175,7 +168,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x04,
             bitSize      =  1,
             bitOffset    =  0x03,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
         ))
@@ -186,7 +178,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x04,
             bitSize      =  1,
             bitOffset    =  0x04,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
         ))
@@ -197,7 +188,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x04,
             bitSize      =  1,
             bitOffset    =  0x05,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
         ))
@@ -208,7 +198,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x08,
             bitSize      =  16,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RW",
         ))
 
@@ -218,7 +207,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x0C,
             bitSize      =  32,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RW",
         ))
 
@@ -228,7 +216,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x10,
             bitSize      =  32,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RO",
             number       =  2,
             stride       =  4,
@@ -241,7 +228,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x18,
             bitSize      =  32,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RO",
             number       =  numBuffers,
             stride       =  4,
@@ -254,7 +240,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x28,
             bitSize      =  32,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
         ))
@@ -265,7 +250,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x2C,
             bitSize      =  32,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
         ))       
@@ -276,10 +260,33 @@ class DaqMuxV2(pr.Device):
             offset       =  0x30,
             bitSize      =  32,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
-        ))               
+        ))
+
+        self.add(pr.RemoteVariable(   
+            name         = "AXI_ADDR_WIDTH_G",
+            offset       =  0x34,
+            bitSize      =  8,
+            bitOffset    =  0,
+            mode         = 'RO',
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "N_DATA_IN_G",
+            offset       =  0x34,
+            bitSize      =  8,
+            bitOffset    =  8,
+            mode         = 'RO',
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "N_DATA_OUT_G",
+            offset       =  0x34,
+            bitSize      =  8,
+            bitOffset    =  16,
+            mode         = 'RO',
+        ))             
 
         self.addRemoteVariables(   
             name         = "InputMuxSel",
@@ -332,7 +339,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x80,
             bitSize      =  1,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RO",
             number       =  numBuffers,
             stride       =  4,
@@ -345,7 +351,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x80,
             bitSize      =  1,
             bitOffset    =  0x01,
-            base         = pr.UInt,
             mode         = "RO",
             number       =  numBuffers,
             stride       =  4,
@@ -358,7 +363,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x80,
             bitSize      =  1,
             bitOffset    =  0x02,
-            base         = pr.UInt,
             mode         = "RO",
             number       =  numBuffers,
             stride       =  4,
@@ -371,7 +375,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x80,
             bitSize      =  1,
             bitOffset    =  0x03,
-            base         = pr.UInt,
             mode         = "RO",
             number       =  numBuffers,
             stride       =  4,
@@ -384,7 +387,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x80,
             bitSize      =  1,
             bitOffset    =  0x04,
-            base         = pr.UInt,
             mode         = "RO",
             number       =  numBuffers,
             stride       =  4,
@@ -397,7 +399,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x80,
             bitSize      =  1,
             bitOffset    =  0x05,
-            base         = pr.UInt,
             mode         = "RO",
             number       =  numBuffers,
             stride       =  4,
@@ -410,7 +411,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x80,
             bitSize      =  26,
             bitOffset    =  0x06,
-            base         = pr.UInt,
             mode         = "RO",
             number       =  numBuffers,
             stride       =  4,
@@ -423,7 +423,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0xC0,
             bitSize      =  5,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RW",
             number       =  numBuffers,
             stride       =  4,

--- a/python/DaqMuxV2/DaqMuxV2.py
+++ b/python/DaqMuxV2/DaqMuxV2.py
@@ -23,6 +23,7 @@ class DaqMuxV2(pr.Device):
     def __init__(   self,       
             name        = "DaqMuxV2",
             description = "Waveform Data Acquisition Module",
+            numBuffers  = 4,
             **kwargs):
         super().__init__(name=name, description=description, **kwargs)
 
@@ -242,7 +243,7 @@ class DaqMuxV2(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RO",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             pollInterval =  1,                            
         )
@@ -287,7 +288,7 @@ class DaqMuxV2(pr.Device):
             bitSize      =  5,
             bitOffset    =  0x00,
             mode         = "RW",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             enum         = {
                    0 : "Disabled",
@@ -333,7 +334,7 @@ class DaqMuxV2(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RO",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             pollInterval =  1,                            
         )
@@ -346,7 +347,7 @@ class DaqMuxV2(pr.Device):
             bitOffset    =  0x01,
             base         = pr.UInt,
             mode         = "RO",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             pollInterval =  1,                            
         )
@@ -359,7 +360,7 @@ class DaqMuxV2(pr.Device):
             bitOffset    =  0x02,
             base         = pr.UInt,
             mode         = "RO",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             pollInterval =  1,                            
         )
@@ -372,7 +373,7 @@ class DaqMuxV2(pr.Device):
             bitOffset    =  0x03,
             base         = pr.UInt,
             mode         = "RO",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             pollInterval =  1,                            
         )
@@ -385,7 +386,7 @@ class DaqMuxV2(pr.Device):
             bitOffset    =  0x04,
             base         = pr.UInt,
             mode         = "RO",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             pollInterval =  1,                            
         )
@@ -398,7 +399,7 @@ class DaqMuxV2(pr.Device):
             bitOffset    =  0x05,
             base         = pr.UInt,
             mode         = "RO",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             pollInterval =  1,                            
         )
@@ -411,7 +412,7 @@ class DaqMuxV2(pr.Device):
             bitOffset    =  0x06,
             base         = pr.UInt,
             mode         = "RO",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             pollInterval =  1,                            
         )
@@ -424,7 +425,7 @@ class DaqMuxV2(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
         )
 
@@ -435,7 +436,7 @@ class DaqMuxV2(pr.Device):
             bitSize      =  1,
             bitOffset    =  0x05,
             mode         = "RW",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             enum         = {
                 0 : "D32-bit",
@@ -450,7 +451,7 @@ class DaqMuxV2(pr.Device):
             bitSize      =  1,
             bitOffset    =  0x06,
             mode         = "RW",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             enum         = {
                 0 : "Unsigned",
@@ -465,7 +466,7 @@ class DaqMuxV2(pr.Device):
             bitSize      =  1,
             bitOffset    =  0x07,
             mode         = "RW",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             enum         = {
                 0 : "Disabled",


### PR DESCRIPTION
### Desscription
- Default of WAVEFORM_NUM_LANES_G=4
- To implement in FW, you must set WAVEFORM_NUM_LANES_G for both AppTop.vhd and AmcCarrierCoreAdv.vhd to be the same
- To implement in SW, you must set TopLevel.py's numWaveformBuffers to be the same as FWWAVEFORM_NUM_LANES_G