### PR TITLE
v2.6.5 release candidate

### DIFF
--- a/AmcCarrierCore/core/AmcCarrierBsa.vhd
+++ b/AmcCarrierCore/core/AmcCarrierBsa.vhd
@@ -369,7 +369,7 @@ begin
    --          AXI_BURST_G         => AXI_BURST_G,
    --          AXI_CACHE_G         => AXI_CACHE_G,
                ACK_WAIT_BVALID_G   => false,
-               AXI_STREAM_CONFIG_G => ETH_AXIS_CONFIG_C,
+               AXI_STREAM_CONFIG_G => AXIS_8BYTE_CONFIG_C,
                UNALIGNED_ACCESS_G  => false,
                BYTE_ACCESS_G       => false,
                WRITE_EN_G          => true,

--- a/AmcCarrierCore/core/AmcCarrierPkg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierPkg.vhd
@@ -94,7 +94,8 @@ package AmcCarrierPkg is
    constant APP_BLEN_TYPE_C       : AppType := toSlv(12, AppType'length);
    constant APP_LLRF_TYPE_C       : AppType := toSlv(13, AppType'length);
    constant APP_EXTREF_GEN_TYPE_C : AppType := toSlv(14, AppType'length);  --Timing Generator with external reference
-
+   constant APP_FWS_TYPE_C        : AppType := toSlv(15, AppType'length);  --Fast Wire Scanner
+                                                     
    constant APP_BPM_STRIPLINE_TYPE_C : AppType := toSlv(100, AppType'length);
    constant APP_BPM_CAVITY_TYPE_C    : AppType := toSlv(101, AppType'length);
 

--- a/AmcCarrierCore/core/AmcCarrierPkg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierPkg.vhd
@@ -80,7 +80,8 @@ package AmcCarrierPkg is
    -- 06/24/2019 (0x02060200): https://github.com/slaclab/amc-carrier-core/releases/tag/v2.6.2
    -- 07/03/2019 (0x02060300): https://github.com/slaclab/amc-carrier-core/releases/tag/v2.6.3
    -- 08/05/2019 (0x02060400): https://github.com/slaclab/amc-carrier-core/releases/tag/v2.6.4
-   constant AMC_CARRIER_CORE_VERSION_C : slv(31 downto 0) := x"02_06_04_00";
+   -- 09/23/2019 (0x02060500): https://github.com/slaclab/amc-carrier-core/releases/tag/v2.6.5
+   constant AMC_CARRIER_CORE_VERSION_C : slv(31 downto 0) := x"02_06_05_00";
 
    -----------------------------------------------------------
    -- Application: Configurations, Constants and Records Types

--- a/AmcCarrierCore/core/AmcCarrierPkg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierPkg.vhd
@@ -116,7 +116,7 @@ package AmcCarrierPkg is
    -------------------------------------------------------------------------------------------------
    -- Ethernet stream configurations
    -------------------------------------------------------------------------------------------------
-   constant ETH_AXIS_CONFIG_C : AxiStreamConfigType := ssiAxiStreamConfig(8, TKEEP_COMP_C, TUSER_FIRST_LAST_C, 8);  -- Use 8 tDest bits
+   constant AXIS_8BYTE_CONFIG_C : AxiStreamConfigType := ssiAxiStreamConfig(8, TKEEP_COMP_C, TUSER_FIRST_LAST_C, 8);  -- Use 8 tDest bits
 
    -- BSA stream indicies
    constant BSA_MEM_AXIS_INDEX_C             : integer := 0;

--- a/AmcCarrierCore/core/AmcCarrierSysReg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierSysReg.vhd
@@ -1,8 +1,6 @@
 -------------------------------------------------------------------------------
 -- File       : AmcCarrierSysReg.vhd
 -- Company    : SLAC National Accelerator Laboratory
--- Created    : 2015-07-08
--- Last update: 2018-03-23
 -------------------------------------------------------------------------------
 -- Description:
 -------------------------------------------------------------------------------
@@ -102,6 +100,9 @@ entity AmcCarrierSysReg is
       -- Configuration PROM Ports
       calScl            : inout sl;
       calSda            : inout sl;
+      -- VCCINT DC/DC Ports
+      pwrScl            : inout sl := 'Z';
+      pwrSda            : inout sl := 'Z';
       -- Clock Cleaner Ports
       timingClkScl      : inout sl;
       timingClkSda      : inout sl;
@@ -118,7 +119,7 @@ architecture mapping of AmcCarrierSysReg is
    -- FSBL Timeout Duration
    constant TIMEOUT_C : integer := integer(10.0 / AXI_CLK_PERIOD_C);
 
-   constant NUM_AXI_MASTERS_C : natural := 14;
+   constant NUM_AXI_MASTERS_C : natural := 15;
 
    constant VERSION_INDEX_C    : natural := 0;
    constant SYSMON_INDEX_C     : natural := 1;
@@ -133,7 +134,8 @@ architecture mapping of AmcCarrierSysReg is
    constant ETH_INDEX_C        : natural := 10;
    constant DDR_INDEX_C        : natural := 11;
    constant MPS_INDEX_C        : natural := 12;
-   constant APP_INDEX_C        : natural := 13;
+   constant PWR_I2C_INDEX_C    : natural := 13;
+   constant APP_INDEX_C        : natural := 14;
 
    constant AXI_CROSSBAR_MASTERS_CONFIG_C : AxiLiteCrossbarMasterConfigArray(NUM_AXI_MASTERS_C-1 downto 0) := (
       VERSION_INDEX_C    => (
@@ -188,6 +190,10 @@ architecture mapping of AmcCarrierSysReg is
          baseAddr        => MPS_ADDR_C,
          addrBits        => 24,
          connectivity    => x"FFFF"),
+      PWR_I2C_INDEX_C    => (
+         baseAddr        => PWR_I2C_ADDR_C,
+         addrBits        => 24,
+         connectivity    => x"FFFF"),
       APP_INDEX_C        => (
          baseAddr        => APP_ADDR_C,
          addrBits        => 31,
@@ -207,10 +213,17 @@ architecture mapping of AmcCarrierSysReg is
          addrSize   => 8,               -- in units of bits
          endianness => '1'));           -- Big endian
 
+   constant PWR_DEVICE_MAP_C : I2cAxiLiteDevArray(0 to 0) := (
+      0             => MakeI2cAxiLiteDevType(
+         i2cAddress => "0001010",  -- EM2280P01QI: ADDR1=0Ohm, ADDR0=10kOhm --> Address=0x0A
+         dataSize   => 16,              -- in units of bits
+         addrSize   => 8,               -- in units of bits
+         endianness => '1'));           -- Big endian         
+
    signal mAxilWriteMasters : AxiLiteWriteMasterArray(NUM_AXI_MASTERS_C-1 downto 0);
-   signal mAxilWriteSlaves  : AxiLiteWriteSlaveArray(NUM_AXI_MASTERS_C-1 downto 0);
+   signal mAxilWriteSlaves  : AxiLiteWriteSlaveArray(NUM_AXI_MASTERS_C-1 downto 0) := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
    signal mAxilReadMasters  : AxiLiteReadMasterArray(NUM_AXI_MASTERS_C-1 downto 0);
-   signal mAxilReadSlaves   : AxiLiteReadSlaveArray(NUM_AXI_MASTERS_C-1 downto 0);
+   signal mAxilReadSlaves   : AxiLiteReadSlaveArray(NUM_AXI_MASTERS_C-1 downto 0)  := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
 
    signal bootCsL  : sl;
    signal bootSck  : sl;
@@ -258,11 +271,11 @@ begin
    --------------------------
    U_Version : entity work.AxiVersion
       generic map (
-         TPD_G            => TPD_G,
-         BUILD_INFO_G     => BUILD_INFO_G,
-         CLK_PERIOD_G     => 6.4E-9,
-         XIL_DEVICE_G     => "ULTRASCALE",
-         EN_DEVICE_DNA_G  => true)
+         TPD_G           => TPD_G,
+         BUILD_INFO_G    => BUILD_INFO_G,
+         CLK_PERIOD_G    => 6.4E-9,
+         XIL_DEVICE_G    => "ULTRASCALE",
+         EN_DEVICE_DNA_G => true)
       port map (
          -- AXI-Lite Interface
          axiClk         => axilClk,
@@ -313,8 +326,8 @@ begin
 
    U_Iprog : entity work.Iprog
       generic map (
-         TPD_G         => TPD_G,
-         XIL_DEVICE_G  => "ULTRASCALE")
+         TPD_G        => TPD_G,
+         XIL_DEVICE_G => "ULTRASCALE")
       port map (
          clk         => axilClk,
          rst         => axilRst,
@@ -512,6 +525,28 @@ begin
          -- Clocks and Resets
          axilClk         => axilClk,
          axilRst         => axilRst);
+
+   -------------------------------
+   -- AXI-Lite: PWR Monitor Module
+   -------------------------------
+   AxiI2cRegMaster_3 : entity work.AxiI2cRegMaster
+      generic map (
+         TPD_G          => TPD_G,
+         I2C_SCL_FREQ_G => 100.0E+3,    -- units of Hz
+         DEVICE_MAP_G   => PWR_DEVICE_MAP_C,
+         AXI_CLK_FREQ_G => AXI_CLK_FREQ_C)
+      port map (
+         -- I2C Ports
+         scl            => pwrScl,
+         sda            => pwrSda,
+         -- AXI-Lite Register Interface
+         axiReadMaster  => mAxilReadMasters(PWR_I2C_INDEX_C),
+         axiReadSlave   => mAxilReadSlaves(PWR_I2C_INDEX_C),
+         axiWriteMaster => mAxilWriteMasters(PWR_I2C_INDEX_C),
+         axiWriteSlave  => mAxilWriteSlaves(PWR_I2C_INDEX_C),
+         -- Clocks and Resets
+         axiClk         => axilClk,
+         axiRst         => axilRst);
 
    --------------------------------------
    -- Map the AXI-Lite to Timing Firmware

--- a/AmcCarrierCore/core/AmcCarrierSysReg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierSysReg.vhd
@@ -104,8 +104,8 @@ entity AmcCarrierSysReg is
       pwrScl            : inout sl := 'Z';
       pwrSda            : inout sl := 'Z';
       -- Clock Cleaner Ports
-      timingClkScl      : inout sl;
-      timingClkSda      : inout sl;
+      timingClkScl      : inout sl := 'Z';
+      timingClkSda      : inout sl := 'Z';
       -- DDR3L SO-DIMM Ports
       ddrScl            : inout sl;
       ddrSda            : inout sl;
@@ -454,24 +454,24 @@ begin
    ---------------------------------
    -- AXI-Lite: Clock Cleaner Module
    ---------------------------------
-   AxiI2cRegMaster_1 : entity work.AxiI2cRegMaster
-      generic map (
-         TPD_G          => TPD_G,
-         I2C_SCL_FREQ_G => 100.0E+3,    -- units of Hz
-         DEVICE_MAP_G   => TIME_DEVICE_MAP_C,
-         AXI_CLK_FREQ_G => AXI_CLK_FREQ_C)
-      port map (
-         -- I2C Ports
-         scl            => timingClkScl,
-         sda            => timingClkSda,
-         -- AXI-Lite Register Interface
-         axiReadMaster  => mAxilReadMasters(CLK_I2C_INDEX_C),
-         axiReadSlave   => mAxilReadSlaves(CLK_I2C_INDEX_C),
-         axiWriteMaster => mAxilWriteMasters(CLK_I2C_INDEX_C),
-         axiWriteSlave  => mAxilWriteSlaves(CLK_I2C_INDEX_C),
-         -- Clocks and Resets
-         axiClk         => axilClk,
-         axiRst         => axilRst);
+--   AxiI2cRegMaster_1 : entity work.AxiI2cRegMaster
+--      generic map (
+--         TPD_G          => TPD_G,
+--         I2C_SCL_FREQ_G => 100.0E+3,    -- units of Hz
+--         DEVICE_MAP_G   => TIME_DEVICE_MAP_C,
+--         AXI_CLK_FREQ_G => AXI_CLK_FREQ_C)
+--      port map (
+--         -- I2C Ports
+--         scl            => timingClkScl,
+--         sda            => timingClkSda,
+--         -- AXI-Lite Register Interface
+--         axiReadMaster  => mAxilReadMasters(CLK_I2C_INDEX_C),
+--         axiReadSlave   => mAxilReadSlaves(CLK_I2C_INDEX_C),
+--         axiWriteMaster => mAxilWriteMasters(CLK_I2C_INDEX_C),
+--         axiWriteSlave  => mAxilWriteSlaves(CLK_I2C_INDEX_C),
+--         -- Clocks and Resets
+--         axiClk         => axilClk,
+--         axiRst         => axilRst);
 
    -------------------------------
    -- AXI-Lite: DDR Monitor Module

--- a/AmcCarrierCore/core/AmcCarrierSysReg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierSysReg.vhd
@@ -219,7 +219,7 @@ architecture mapping of AmcCarrierSysReg is
          dataSize    => 16,              -- in units of bits
          addrSize    => 8,               -- in units of bits
          repeatStart => '1',             -- repeated start 
-         endianness  => '1'));           -- Big endian         
+         endianness  => '0'));           -- Little endian         
 
    signal mAxilWriteMasters : AxiLiteWriteMasterArray(NUM_AXI_MASTERS_C-1 downto 0);
    signal mAxilWriteSlaves  : AxiLiteWriteSlaveArray(NUM_AXI_MASTERS_C-1 downto 0) := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);

--- a/AmcCarrierCore/core/AmcCarrierSysReg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierSysReg.vhd
@@ -215,10 +215,11 @@ architecture mapping of AmcCarrierSysReg is
 
    constant PWR_DEVICE_MAP_C : I2cAxiLiteDevArray(0 to 0) := (
       0             => MakeI2cAxiLiteDevType(
-         i2cAddress => "0001010",  -- EM2280P01QI: ADDR1=0Ohm, ADDR0=10kOhm --> Address=0x0A
-         dataSize   => 16,              -- in units of bits
-         addrSize   => 8,               -- in units of bits
-         endianness => '1'));           -- Big endian         
+         i2cAddress  => "0001010",  -- EM2280P01QI: ADDR1=0Ohm, ADDR0=10kOhm --> Address=0x0A
+         dataSize    => 16,              -- in units of bits
+         addrSize    => 8,               -- in units of bits
+         repeatStart => '1',             -- repeated start 
+         endianness  => '1'));           -- Big endian         
 
    signal mAxilWriteMasters : AxiLiteWriteMasterArray(NUM_AXI_MASTERS_C-1 downto 0);
    signal mAxilWriteSlaves  : AxiLiteWriteSlaveArray(NUM_AXI_MASTERS_C-1 downto 0) := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);

--- a/AmcCarrierCore/core/AmcCarrierSysReg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierSysReg.vhd
@@ -98,8 +98,8 @@ entity AmcCarrierSysReg is
       ipmcScl           : inout sl;
       ipmcSda           : inout sl;
       -- Configuration PROM Ports
-      calScl            : inout sl;
-      calSda            : inout sl;
+      calScl            : inout sl := 'Z';
+      calSda            : inout sl := 'Z';
       -- VCCINT DC/DC Ports
       pwrScl            : inout sl := 'Z';
       pwrSda            : inout sl := 'Z';
@@ -107,8 +107,8 @@ entity AmcCarrierSysReg is
       timingClkScl      : inout sl := 'Z';
       timingClkSda      : inout sl := 'Z';
       -- DDR3L SO-DIMM Ports
-      ddrScl            : inout sl;
-      ddrSda            : inout sl;
+      ddrScl            : inout sl := 'Z';
+      ddrSda            : inout sl := 'Z';
       -- SYSMON Ports
       vPIn              : in    sl;
       vNIn              : in    sl);
@@ -431,25 +431,25 @@ begin
    ----------------------------------------
    -- AXI-Lite: Configuration Memory Module
    ----------------------------------------
-   AxiI2cRegMaster_0 : entity work.AxiI2cEeprom
-      generic map (
-         TPD_G          => TPD_G,
-         ADDR_WIDTH_G   => 13,
-         I2C_ADDR_G     => "1010000",
-         I2C_SCL_FREQ_G => 400.0E+3,    -- units of Hz
-         AXI_CLK_FREQ_G => AXI_CLK_FREQ_C)
-      port map (
-         -- I2C Ports
-         scl             => calScl,
-         sda             => calSda,
-         -- AXI-Lite Register Interface
-         axilReadMaster  => mAxilReadMasters(CONFIG_I2C_INDEX_C),
-         axilReadSlave   => mAxilReadSlaves(CONFIG_I2C_INDEX_C),
-         axilWriteMaster => mAxilWriteMasters(CONFIG_I2C_INDEX_C),
-         axilWriteSlave  => mAxilWriteSlaves(CONFIG_I2C_INDEX_C),
-         -- Clocks and Resets
-         axilClk         => axilClk,
-         axilRst         => axilRst);
+--   AxiI2cRegMaster_0 : entity work.AxiI2cEeprom
+--      generic map (
+--         TPD_G          => TPD_G,
+--         ADDR_WIDTH_G   => 13,
+--         I2C_ADDR_G     => "1010000",
+--         I2C_SCL_FREQ_G => 400.0E+3,    -- units of Hz
+--         AXI_CLK_FREQ_G => AXI_CLK_FREQ_C)
+--      port map (
+--         -- I2C Ports
+--         scl             => calScl,
+--         sda             => calSda,
+--         -- AXI-Lite Register Interface
+--         axilReadMaster  => mAxilReadMasters(CONFIG_I2C_INDEX_C),
+--         axilReadSlave   => mAxilReadSlaves(CONFIG_I2C_INDEX_C),
+--         axilWriteMaster => mAxilWriteMasters(CONFIG_I2C_INDEX_C),
+--         axilWriteSlave  => mAxilWriteSlaves(CONFIG_I2C_INDEX_C),
+--         -- Clocks and Resets
+--         axilClk         => axilClk,
+--         axilRst         => axilRst);
 
    ---------------------------------
    -- AXI-Lite: Clock Cleaner Module
@@ -476,24 +476,24 @@ begin
    -------------------------------
    -- AXI-Lite: DDR Monitor Module
    -------------------------------
-   AxiI2cRegMaster_2 : entity work.AxiI2cRegMaster
-      generic map (
-         TPD_G          => TPD_G,
-         I2C_SCL_FREQ_G => 400.0E+3,    -- units of Hz
-         DEVICE_MAP_G   => DDR_DEVICE_MAP_C,
-         AXI_CLK_FREQ_G => AXI_CLK_FREQ_C)
-      port map (
-         -- I2C Ports
-         scl            => ddrScl,
-         sda            => ddrSda,
-         -- AXI-Lite Register Interface
-         axiReadMaster  => mAxilReadMasters(DDR_I2C_INDEX_C),
-         axiReadSlave   => mAxilReadSlaves(DDR_I2C_INDEX_C),
-         axiWriteMaster => mAxilWriteMasters(DDR_I2C_INDEX_C),
-         axiWriteSlave  => mAxilWriteSlaves(DDR_I2C_INDEX_C),
-         -- Clocks and Resets
-         axiClk         => axilClk,
-         axiRst         => axilRst);
+--   AxiI2cRegMaster_2 : entity work.AxiI2cRegMaster
+--      generic map (
+--         TPD_G          => TPD_G,
+--         I2C_SCL_FREQ_G => 400.0E+3,    -- units of Hz
+--         DEVICE_MAP_G   => DDR_DEVICE_MAP_C,
+--         AXI_CLK_FREQ_G => AXI_CLK_FREQ_C)
+--      port map (
+--         -- I2C Ports
+--         scl            => ddrScl,
+--         sda            => ddrSda,
+--         -- AXI-Lite Register Interface
+--         axiReadMaster  => mAxilReadMasters(DDR_I2C_INDEX_C),
+--         axiReadSlave   => mAxilReadSlaves(DDR_I2C_INDEX_C),
+--         axiWriteMaster => mAxilWriteMasters(DDR_I2C_INDEX_C),
+--         axiWriteSlave  => mAxilWriteSlaves(DDR_I2C_INDEX_C),
+--         -- Clocks and Resets
+--         axiClk         => axilClk,
+--         axiRst         => axilRst);
 
    -----------------------
    -- AXI-Lite: BSI Module

--- a/AmcCarrierCore/core/AmcCarrierSysReg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierSysReg.vhd
@@ -214,12 +214,12 @@ architecture mapping of AmcCarrierSysReg is
          endianness => '1'));           -- Big endian
 
    constant PWR_DEVICE_MAP_C : I2cAxiLiteDevArray(0 to 0) := (
-      0             => MakeI2cAxiLiteDevType(
+      0              => MakeI2cAxiLiteDevType(
          i2cAddress  => "0001010",  -- EM2280P01QI: ADDR1=0Ohm, ADDR0=10kOhm --> Address=0x0A
-         dataSize    => 16,              -- in units of bits
-         addrSize    => 8,               -- in units of bits
-         repeatStart => '1',             -- repeated start 
-         endianness  => '0'));           -- Little endian         
+         dataSize    => 16,             -- in units of bits
+         addrSize    => 8,              -- in units of bits
+         repeatStart => '1',            -- repeated start 
+         endianness  => '0'));          -- Little endian         
 
    signal mAxilWriteMasters : AxiLiteWriteMasterArray(NUM_AXI_MASTERS_C-1 downto 0);
    signal mAxilWriteSlaves  : AxiLiteWriteSlaveArray(NUM_AXI_MASTERS_C-1 downto 0) := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
@@ -530,24 +530,26 @@ begin
    -------------------------------
    -- AXI-Lite: PWR Monitor Module
    -------------------------------
-   AxiI2cRegMaster_3 : entity work.AxiI2cRegMaster
-      generic map (
-         TPD_G          => TPD_G,
-         I2C_SCL_FREQ_G => 100.0E+3,    -- units of Hz
-         DEVICE_MAP_G   => PWR_DEVICE_MAP_C,
-         AXI_CLK_FREQ_G => AXI_CLK_FREQ_C)
-      port map (
-         -- I2C Ports
-         scl            => pwrScl,
-         sda            => pwrSda,
-         -- AXI-Lite Register Interface
-         axiReadMaster  => mAxilReadMasters(PWR_I2C_INDEX_C),
-         axiReadSlave   => mAxilReadSlaves(PWR_I2C_INDEX_C),
-         axiWriteMaster => mAxilWriteMasters(PWR_I2C_INDEX_C),
-         axiWriteSlave  => mAxilWriteSlaves(PWR_I2C_INDEX_C),
-         -- Clocks and Resets
-         axiClk         => axilClk,
-         axiRst         => axilRst);
+   GEN_PWR_I2C : if (ULTRASCALE_PLUS_C) generate
+      AxiI2cRegMaster_3 : entity work.AxiI2cRegMaster
+         generic map (
+            TPD_G          => TPD_G,
+            I2C_SCL_FREQ_G => 100.0E+3,  -- units of Hz
+            DEVICE_MAP_G   => PWR_DEVICE_MAP_C,
+            AXI_CLK_FREQ_G => AXI_CLK_FREQ_C)
+         port map (
+            -- I2C Ports
+            scl            => pwrScl,
+            sda            => pwrSda,
+            -- AXI-Lite Register Interface
+            axiReadMaster  => mAxilReadMasters(PWR_I2C_INDEX_C),
+            axiReadSlave   => mAxilReadSlaves(PWR_I2C_INDEX_C),
+            axiWriteMaster => mAxilWriteMasters(PWR_I2C_INDEX_C),
+            axiWriteSlave  => mAxilWriteSlaves(PWR_I2C_INDEX_C),
+            -- Clocks and Resets
+            axiClk         => axilClk,
+            axiRst         => axilRst);
+   end generate;
 
    --------------------------------------
    -- Map the AXI-Lite to Timing Firmware

--- a/AmcCarrierCore/core/AmcCarrierSysRegPkg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierSysRegPkg.vhd
@@ -1,8 +1,6 @@
 -------------------------------------------------------------------------------
 -- File       : AmcCarrierSysRegPkg.vhd
 -- Company    : SLAC National Accelerator Laboratory
--- Created    : 2015-09-08
--- Last update: 2017-04-26
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -39,6 +37,7 @@ package AmcCarrierSysRegPkg is
    constant ETH_ADDR_C        : slv(31 downto 0) := x"0A000000";
    constant DDR_ADDR_C        : slv(31 downto 0) := x"0B000000";
    constant MPS_ADDR_C        : slv(31 downto 0) := x"0C000000";
+   constant PWR_I2C_ADDR_C    : slv(31 downto 0) := x"0D000000";
    constant APP_ADDR_C        : slv(31 downto 0) := x"80000000";
 
    constant XBAR_TIME_GEN_C : Slv2Array(3 downto 0) := (

--- a/AmcCarrierCore/core/AmcCarrierTiming.vhd
+++ b/AmcCarrierCore/core/AmcCarrierTiming.vhd
@@ -41,8 +41,12 @@ entity AmcCarrierTiming is
       DISABLE_TIME_GT_G : boolean  := false;
       CORE_TRIGGERS_G   : natural  := 16;
       TRIG_PIPE_G       : natural  := 0;
+      CLKSEL_MODE_G     : string   := "SELECT"; -- "LCLSI","LCLSII"
       STREAM_L1_G       : boolean  := true;
-      RX_CLK_MMCM_G     : boolean  := false);
+      AXIL_RINGB_G      : boolean  := true;
+      ASYNC_G           : boolean  := true;
+      RX_CLK_MMCM_G     : boolean  := false;
+      USE_TPGMINI_G     : boolean  := true);
    port (
       stableClk            : in  sl;
       stableRst            : in  sl;
@@ -311,7 +315,11 @@ begin
          TPGEN_G           => TIME_GEN_APP_G,
          STREAM_L1_G       => STREAM_L1_G,
          ETHMSG_AXIS_CFG_G => EMAC_AXIS_CONFIG_C,
-         AXIL_BASE_ADDR_G  => AXI_CROSSBAR_MASTERS_CONFIG_C(AXIL_CORE_INDEX_C).baseAddr)
+         AXIL_BASE_ADDR_G  => AXI_CROSSBAR_MASTERS_CONFIG_C(AXIL_CORE_INDEX_C).baseAddr,
+	 AXIL_RINGB_G      => AXIL_RINGB_G,
+	 ASYNC_G           => ASYNC_G,
+	 CLKSEL_MODE_G     => CLKSEL_MODE_G,
+         USE_TPGMINI_G     => USE_TPGMINI_G)
       port map (
          gtTxUsrClk      => txUsrClk,
          gtTxUsrRst      => txUsrRst,

--- a/AmcCarrierCore/core/kintexu/AmcCarrierEth.vhd
+++ b/AmcCarrierCore/core/kintexu/AmcCarrierEth.vhd
@@ -481,7 +481,7 @@ begin
          READY_EN_G          => true,
          -- AXI Stream Port Configurations
          SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
-         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
+         MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
       port map (
          -- Clock and reset
          axisClk     => axilClk,
@@ -499,11 +499,11 @@ begin
          EN_TIMEOUT_G        => true,
          MAXIS_CLK_FREQ_G    => AXI_CLK_FREQ_C,
          TIMEOUT_G           => 1.0E-3,
-         FRAME_LIMIT_G       => (ETH_USR_FRAME_LIMIT_G/16),
+         FRAME_LIMIT_G       => (ETH_USR_FRAME_LIMIT_G/EMAC_AXIS_CONFIG_C.TDATA_BYTES_C),
          COMMON_CLK_G        => true,
          SLAVE_FIFO_G        => false,
          MASTER_FIFO_G       => false,
-         SLAVE_AXI_CONFIG_G  => AXIS_8BYTE_CONFIG_C,
+         SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
          MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
       port map (
          -- Slave Port
@@ -535,7 +535,7 @@ begin
          READY_EN_G          => true,
          -- AXI Stream Port Configurations
          SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
-         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
+         MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
       port map (
          -- Clock and reset
          axisClk     => axilClk,
@@ -553,11 +553,11 @@ begin
          EN_TIMEOUT_G        => true,
          MAXIS_CLK_FREQ_G    => AXI_CLK_FREQ_C,
          TIMEOUT_G           => 1.0E-3,
-         FRAME_LIMIT_G       => (ETH_USR_FRAME_LIMIT_G/16),
+         FRAME_LIMIT_G       => (ETH_USR_FRAME_LIMIT_G/EMAC_AXIS_CONFIG_C.TDATA_BYTES_C),
          COMMON_CLK_G        => true,
          SLAVE_FIFO_G        => false,
          MASTER_FIFO_G       => false,
-         SLAVE_AXI_CONFIG_G  => AXIS_8BYTE_CONFIG_C,
+         SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
          MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
       port map (
          -- Slave Port

--- a/AmcCarrierCore/core/kintexu/AmcCarrierEth.vhd
+++ b/AmcCarrierCore/core/kintexu/AmcCarrierEth.vhd
@@ -486,8 +486,8 @@ begin
          COMMON_CLK_G        => true,
          SLAVE_FIFO_G        => false,
          MASTER_FIFO_G       => false,
-         SLAVE_AXI_CONFIG_G  => ETH_AXIS_CONFIG_C,
-         MASTER_AXI_CONFIG_G => ETH_AXIS_CONFIG_C)
+         SLAVE_AXI_CONFIG_G  => AXIS_8BYTE_CONFIG_C,
+         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
       port map (
          -- Slave Port
          sAxisClk    => axilClk,
@@ -523,8 +523,8 @@ begin
          COMMON_CLK_G        => true,
          SLAVE_FIFO_G        => false,
          MASTER_FIFO_G       => false,
-         SLAVE_AXI_CONFIG_G  => ETH_AXIS_CONFIG_C,
-         MASTER_AXI_CONFIG_G => ETH_AXIS_CONFIG_C)
+         SLAVE_AXI_CONFIG_G  => AXIS_8BYTE_CONFIG_C,
+         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
       port map (
          -- Slave Port
          sAxisClk    => axilClk,

--- a/AmcCarrierCore/core/kintexu/AmcCarrierEth.vhd
+++ b/AmcCarrierCore/core/kintexu/AmcCarrierEth.vhd
@@ -474,8 +474,25 @@ begin
    ----------------------
    -- BP Messenger Server
    ----------------------
-   ibBpMsgServerMaster                  <= obServerMasters(UDP_SRV_BP_MGS_IDX_C);
-   obServerSlaves(UDP_SRV_BP_MGS_IDX_C) <= ibBpMsgServerSlave;
+   U_Resize_Server : entity work.AxiStreamResize
+      generic map (
+         -- General Configurations
+         TPD_G               => TPD_G,
+         READY_EN_G          => true,
+         -- AXI Stream Port Configurations
+         SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
+         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
+      port map (
+         -- Clock and reset
+         axisClk     => axilClk,
+         axisRst     => axilRst,
+         -- Slave Port
+         sAxisMaster => obServerMasters(UDP_SRV_BP_MGS_IDX_C),
+         sAxisSlave  => obServerSlaves(UDP_SRV_BP_MGS_IDX_C),
+         -- Master Port
+         mAxisMaster => ibBpMsgServerMaster,
+         mAxisSlave  => ibBpMsgServerSlave);
+
    U_ServerLimiter : entity work.SsiFrameLimiter
       generic map (
          TPD_G               => TPD_G,
@@ -487,7 +504,7 @@ begin
          SLAVE_FIFO_G        => false,
          MASTER_FIFO_G       => false,
          SLAVE_AXI_CONFIG_G  => AXIS_8BYTE_CONFIG_C,
-         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
+         MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
       port map (
          -- Slave Port
          sAxisClk    => axilClk,
@@ -511,8 +528,25 @@ begin
    ----------------------
    -- BP Messenger Client
    ----------------------
-   ibBpMsgClientMaster                  <= obClientMasters(UDP_CLT_BP_MGS_IDX_C);
-   obClientSlaves(UDP_CLT_BP_MGS_IDX_C) <= ibBpMsgClientSlave;
+   U_Resize_Client : entity work.AxiStreamResize
+      generic map (
+         -- General Configurations
+         TPD_G               => TPD_G,
+         READY_EN_G          => true,
+         -- AXI Stream Port Configurations
+         SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
+         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
+      port map (
+         -- Clock and reset
+         axisClk     => axilClk,
+         axisRst     => axilRst,
+         -- Slave Port
+         sAxisMaster => obClientMasters(UDP_CLT_BP_MGS_IDX_C),
+         sAxisSlave  => obClientSlaves(UDP_CLT_BP_MGS_IDX_C),
+         -- Master Port
+         mAxisMaster => ibBpMsgClientMaster,
+         mAxisSlave  => ibBpMsgClientSlave);
+
    U_ClientLimiter : entity work.SsiFrameLimiter
       generic map (
          TPD_G               => TPD_G,
@@ -524,7 +558,7 @@ begin
          SLAVE_FIFO_G        => false,
          MASTER_FIFO_G       => false,
          SLAVE_AXI_CONFIG_G  => AXIS_8BYTE_CONFIG_C,
-         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
+         MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
       port map (
          -- Slave Port
          sAxisClk    => axilClk,

--- a/AmcCarrierCore/core/kintexuplus/AmcCarrierEth.vhd
+++ b/AmcCarrierCore/core/kintexuplus/AmcCarrierEth.vhd
@@ -481,7 +481,7 @@ begin
          READY_EN_G          => true,
          -- AXI Stream Port Configurations
          SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
-         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
+         MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
       port map (
          -- Clock and reset
          axisClk     => axilClk,
@@ -499,11 +499,11 @@ begin
          EN_TIMEOUT_G        => true,
          MAXIS_CLK_FREQ_G    => AXI_CLK_FREQ_C,
          TIMEOUT_G           => 1.0E-3,
-         FRAME_LIMIT_G       => (ETH_USR_FRAME_LIMIT_G/16),
+         FRAME_LIMIT_G       => (ETH_USR_FRAME_LIMIT_G/EMAC_AXIS_CONFIG_C.TDATA_BYTES_C),
          COMMON_CLK_G        => true,
          SLAVE_FIFO_G        => false,
          MASTER_FIFO_G       => false,
-         SLAVE_AXI_CONFIG_G  => AXIS_8BYTE_CONFIG_C,
+         SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
          MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
       port map (
          -- Slave Port
@@ -535,7 +535,7 @@ begin
          READY_EN_G          => true,
          -- AXI Stream Port Configurations
          SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
-         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
+         MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
       port map (
          -- Clock and reset
          axisClk     => axilClk,
@@ -553,11 +553,11 @@ begin
          EN_TIMEOUT_G        => true,
          MAXIS_CLK_FREQ_G    => AXI_CLK_FREQ_C,
          TIMEOUT_G           => 1.0E-3,
-         FRAME_LIMIT_G       => (ETH_USR_FRAME_LIMIT_G/16),
+         FRAME_LIMIT_G       => (ETH_USR_FRAME_LIMIT_G/EMAC_AXIS_CONFIG_C.TDATA_BYTES_C),
          COMMON_CLK_G        => true,
          SLAVE_FIFO_G        => false,
          MASTER_FIFO_G       => false,
-         SLAVE_AXI_CONFIG_G  => AXIS_8BYTE_CONFIG_C,
+         SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
          MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
       port map (
          -- Slave Port

--- a/AmcCarrierCore/core/kintexuplus/AmcCarrierEth.vhd
+++ b/AmcCarrierCore/core/kintexuplus/AmcCarrierEth.vhd
@@ -486,8 +486,8 @@ begin
          COMMON_CLK_G        => true,
          SLAVE_FIFO_G        => false,
          MASTER_FIFO_G       => false,
-         SLAVE_AXI_CONFIG_G  => ETH_AXIS_CONFIG_C,
-         MASTER_AXI_CONFIG_G => ETH_AXIS_CONFIG_C)
+         SLAVE_AXI_CONFIG_G  => AXIS_8BYTE_CONFIG_C,
+         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
       port map (
          -- Slave Port
          sAxisClk    => axilClk,
@@ -523,8 +523,8 @@ begin
          COMMON_CLK_G        => true,
          SLAVE_FIFO_G        => false,
          MASTER_FIFO_G       => false,
-         SLAVE_AXI_CONFIG_G  => ETH_AXIS_CONFIG_C,
-         MASTER_AXI_CONFIG_G => ETH_AXIS_CONFIG_C)
+         SLAVE_AXI_CONFIG_G  => AXIS_8BYTE_CONFIG_C,
+         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
       port map (
          -- Slave Port
          sAxisClk    => axilClk,

--- a/AmcCarrierCore/core/kintexuplus/AmcCarrierEth.vhd
+++ b/AmcCarrierCore/core/kintexuplus/AmcCarrierEth.vhd
@@ -474,8 +474,25 @@ begin
    ----------------------
    -- BP Messenger Server
    ----------------------
-   ibBpMsgServerMaster                  <= obServerMasters(UDP_SRV_BP_MGS_IDX_C);
-   obServerSlaves(UDP_SRV_BP_MGS_IDX_C) <= ibBpMsgServerSlave;
+   U_Resize_Server : entity work.AxiStreamResize
+      generic map (
+         -- General Configurations
+         TPD_G               => TPD_G,
+         READY_EN_G          => true,
+         -- AXI Stream Port Configurations
+         SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
+         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
+      port map (
+         -- Clock and reset
+         axisClk     => axilClk,
+         axisRst     => axilRst,
+         -- Slave Port
+         sAxisMaster => obServerMasters(UDP_SRV_BP_MGS_IDX_C),
+         sAxisSlave  => obServerSlaves(UDP_SRV_BP_MGS_IDX_C),
+         -- Master Port
+         mAxisMaster => ibBpMsgServerMaster,
+         mAxisSlave  => ibBpMsgServerSlave);
+
    U_ServerLimiter : entity work.SsiFrameLimiter
       generic map (
          TPD_G               => TPD_G,
@@ -487,7 +504,7 @@ begin
          SLAVE_FIFO_G        => false,
          MASTER_FIFO_G       => false,
          SLAVE_AXI_CONFIG_G  => AXIS_8BYTE_CONFIG_C,
-         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
+         MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
       port map (
          -- Slave Port
          sAxisClk    => axilClk,
@@ -511,8 +528,25 @@ begin
    ----------------------
    -- BP Messenger Client
    ----------------------
-   ibBpMsgClientMaster                  <= obClientMasters(UDP_CLT_BP_MGS_IDX_C);
-   obClientSlaves(UDP_CLT_BP_MGS_IDX_C) <= ibBpMsgClientSlave;
+   U_Resize_Client : entity work.AxiStreamResize
+      generic map (
+         -- General Configurations
+         TPD_G               => TPD_G,
+         READY_EN_G          => true,
+         -- AXI Stream Port Configurations
+         SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
+         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
+      port map (
+         -- Clock and reset
+         axisClk     => axilClk,
+         axisRst     => axilRst,
+         -- Slave Port
+         sAxisMaster => obClientMasters(UDP_CLT_BP_MGS_IDX_C),
+         sAxisSlave  => obClientSlaves(UDP_CLT_BP_MGS_IDX_C),
+         -- Master Port
+         mAxisMaster => ibBpMsgClientMaster,
+         mAxisSlave  => ibBpMsgClientSlave);
+
    U_ClientLimiter : entity work.SsiFrameLimiter
       generic map (
          TPD_G               => TPD_G,
@@ -524,7 +558,7 @@ begin
          SLAVE_FIFO_G        => false,
          MASTER_FIFO_G       => false,
          SLAVE_AXI_CONFIG_G  => AXIS_8BYTE_CONFIG_C,
-         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
+         MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
       port map (
          -- Slave Port
          sAxisClk    => axilClk,

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
@@ -2,7 +2,7 @@
 -- File       : AmcCarrierCore.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-07-08
--- Last update: 2018-08-28
+-- Last update: 2019-09-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -33,7 +33,8 @@ entity AmcCarrierCore is
    generic (
       TPD_G                  : time     := 1 ns;
       ETH_USR_FRAME_LIMIT_G  : positive := 4096;   -- 4kB   
-      WAVEFORM_TDATA_BYTES_G : positive := 4;
+      WAVEFORM_NUM_LANES_G   : positive := 4;  -- Number of Waveform lanes per DaqMuxV2
+      WAVEFORM_TDATA_BYTES_G : positive := 4;  -- Waveform stream's tData width (in units of bytes)
       RSSI_ILEAVE_EN_G       : boolean  := false;
       SIM_SPEEDUP_G          : boolean  := false;  -- false = Normal Operation, true = simulation
       DISABLE_BSA_G          : boolean  := false;  -- false = includes BSA engine, true = doesn't build the BSA engine
@@ -429,6 +430,7 @@ begin
          DISABLE_BSA_G          => DISABLE_BSA_G,
          DISABLE_BLD_G          => DISABLE_BLD_G,
          DISABLE_DDR_SRP_G      => DISABLE_DDR_SRP_G,
+         WAVEFORM_NUM_LANES_G   => WAVEFORM_NUM_LANES_G,
          WAVEFORM_TDATA_BYTES_G => WAVEFORM_TDATA_BYTES_G)
       port map (
          -- AXI-Lite Interface (axilClk domain)

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
@@ -44,8 +44,13 @@ entity AmcCarrierCore is
       TIME_GEN_EXTREF_G      : boolean  := false;  -- false = normal application, true = timing generator using external reference
       DISABLE_TIME_GT_G      : boolean  := false;  -- false = normal application, true = doesn't build the Timing GT
       CORE_TRIGGERS_G        : natural  := 16;
-      TRIG_PIPE_G            : natural  := 0;  -- no trigger pipeline by default
-      FSBL_G                 : boolean  := false);  -- false = Normal Operation, true = First Stage Boot loader
+      TRIG_PIPE_G            : natural  := 0;      -- no trigger pipeline by default
+      USE_TPGMINI_G          : boolean  := true;   -- build TPG Mini by default
+      CLKSEL_MODE_G          : string   := "SELECT"; -- "LCLSI","LCLSII"
+      STREAM_L1_G            : boolean  := true;
+      AXIL_RINGB_G           : boolean  := true;
+      ASYNC_G                : boolean  := true;
+      FSBL_G                 : boolean  := false); -- false = Normal Operation, true = First Stage Boot loader
    port (
       -----------------------
       -- Core Ports to AppTop
@@ -365,7 +370,11 @@ begin
          DISABLE_TIME_GT_G => DISABLE_TIME_GT_G,
          CORE_TRIGGERS_G   => CORE_TRIGGERS_G,
          TRIG_PIPE_G       => TRIG_PIPE_G,
-         STREAM_L1_G       => true)
+	 CLKSEL_MODE_G     => CLKSEL_MODE_G,
+	 STREAM_L1_G       => STREAM_L1_G,
+	 AXIL_RINGB_G      => AXIL_RINGB_G,
+	 ASYNC_G           => ASYNC_G,
+         USE_TPGMINI_G     => USE_TPGMINI_G)
       port map (
          stableClk            => fabClk,
          stableRst            => fabRst,

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCoreAdv.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCoreAdv.vhd
@@ -51,7 +51,8 @@ entity AmcCarrierCoreAdv is
       ASYNC_G                : boolean  := true;
       FSBL_G                 : boolean  := false;  -- false = Normal Operation, true = First Stage Boot loader
       APP_TYPE_G             : AppType;
-      WAVEFORM_TDATA_BYTES_G : positive := 4;
+      WAVEFORM_NUM_LANES_G   : positive := 4;  -- Number of Waveform lanes per DaqMuxV2
+      WAVEFORM_TDATA_BYTES_G : positive := 4;  -- Waveform stream's tData width (in units of bytes)
       ETH_USR_FRAME_LIMIT_G  : positive := 4096;   -- 4kB  
       MPS_SLOT_G             : boolean  := false); -- false = Normal Operation, true = MPS message concentrator (Slot#2 only)      
    port (
@@ -397,6 +398,7 @@ begin
    U_Core : entity work.AmcCarrierCore
       generic map (
          TPD_G                  => TPD_G,
+         WAVEFORM_NUM_LANES_G   => WAVEFORM_NUM_LANES_G,
          WAVEFORM_TDATA_BYTES_G => WAVEFORM_TDATA_BYTES_G,
          ETH_USR_FRAME_LIMIT_G  => ETH_USR_FRAME_LIMIT_G,
          RSSI_ILEAVE_EN_G       => RSSI_ILEAVE_EN_G,

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCoreAdv.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCoreAdv.vhd
@@ -1,8 +1,6 @@
 -------------------------------------------------------------------------------
 -- File       : AmcCarrierCoreAdv.vhd
 -- Company    : SLAC National Accelerator Laboratory
--- Created    : 2017-02-04
--- Last update: 2018-08-24
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -107,7 +105,7 @@ entity AmcCarrierCoreAdv is
       recTimingRst         : out   sl;
       gthFabClk            : out   sl;
       stableClk            : out   sl;
-      stableRst            : out   sl;      
+      stableRst            : out   sl;
       -- Misc. Interface (axilClk domain)
       ipmiBsi              : out   BsiBusType;
       ethPhyReady          : out   sl;
@@ -156,6 +154,9 @@ entity AmcCarrierCoreAdv is
       -- Configuration PROM Ports
       calScl               : inout sl;
       calSda               : inout sl;
+      -- VCCINT DC/DC Ports
+      pwrScl               : inout sl                               := 'Z';
+      pwrSda               : inout sl                               := 'Z';
       -- DDR3L SO-DIMM Ports
       ddrClkP              : in    sl;
       ddrClkN              : in    sl;
@@ -220,7 +221,7 @@ architecture mapping of AmcCarrierCoreAdv is
    signal ddrMemError       : sl;
    --  MPS Interface
    signal mpsReadMaster     : AxiLiteReadMasterType;
-   signal mpsReadSlave      : AxiLiteReadSlaveType := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
+   signal mpsReadSlave      : AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
    signal mpsWriteMaster    : AxiLiteWriteMasterType;
    signal mpsWriteSlave     : AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C;
 
@@ -316,6 +317,9 @@ begin
          -- Configuration PROM Ports
          calScl            => calScl,
          calSda            => calSda,
+         -- VCCINT DC/DC Ports
+         pwrScl            => pwrScl,
+         pwrSda            => pwrSda,
          -- Clock Cleaner Ports
          timingClkScl      => timingClkScl,
          timingClkSda      => timingClkSda,
@@ -329,7 +333,7 @@ begin
 --   ------------------
 --   -- Application MPS
 --   ------------------
-   GEN_EN_MPS : if ( DISABLE_MPS_G = false ) generate
+   GEN_EN_MPS : if (DISABLE_MPS_G = false) generate
       U_AppMps : entity work.AppMps
          generic map (
             TPD_G      => TPD_G,
@@ -372,7 +376,7 @@ begin
             mpsTxN          => mpsTxN);
    end generate GEN_EN_MPS;
 
-   GEN_DIS_MPS : if ( DISABLE_MPS_G = true ) generate
+   GEN_DIS_MPS : if (DISABLE_MPS_G = true) generate
       mpsObMasters <= (others => AXI_STREAM_MASTER_INIT_C);
       mpsClkOut    <= '0';
       U_OBUFDS : OBUFDS

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCoreAdv.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCoreAdv.vhd
@@ -43,12 +43,17 @@ entity AmcCarrierCoreAdv is
       TIME_GEN_EXTREF_G      : boolean  := false;  -- false = normal application, true = timing generator using external reference
       DISABLE_TIME_GT_G      : boolean  := false;  -- false = normal application, true = doesn't build the Timing GT
       CORE_TRIGGERS_G        : positive := 16;
-      TRIG_PIPE_G            : natural  := 0;  -- no trigger pipeline by default
+      TRIG_PIPE_G            : natural  := 0;      -- no trigger pipeline by default
+      USE_TPGMINI_G          : boolean  := true;   -- Build TPG Mini by default
+      CLKSEL_MODE_G          : string   := "SELECT"; -- "LCLSI","LCLSII"
+      STREAM_L1_G            : boolean  := true;
+      AXIL_RINGB_G           : boolean  := true;
+      ASYNC_G                : boolean  := true;
       FSBL_G                 : boolean  := false;  -- false = Normal Operation, true = First Stage Boot loader
       APP_TYPE_G             : AppType;
       WAVEFORM_TDATA_BYTES_G : positive := 4;
       ETH_USR_FRAME_LIMIT_G  : positive := 4096;   -- 4kB  
-      MPS_SLOT_G             : boolean  := false);  -- false = Normal Operation, true = MPS message concentrator (Slot#2 only)      
+      MPS_SLOT_G             : boolean  := false); -- false = Normal Operation, true = MPS message concentrator (Slot#2 only)      
    port (
       -----------------------
       -- Core Ports to AppTop
@@ -405,6 +410,11 @@ begin
          DISABLE_TIME_GT_G      => DISABLE_TIME_GT_G,
          CORE_TRIGGERS_G        => CORE_TRIGGERS_G,
          TRIG_PIPE_G            => TRIG_PIPE_G,
+         USE_TPGMINI_G          => USE_TPGMINI_G,
+	 CLKSEL_MODE_G          => CLKSEL_MODE_G,
+	 STREAM_L1_G            => STREAM_L1_G,
+	 AXIL_RINGB_G           => AXIL_RINGB_G,
+	 ASYNC_G                => ASYNC_G,
          FSBL_G                 => FSBL_G)
       port map (
          -----------------------

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCoreBase.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCoreBase.vhd
@@ -51,7 +51,8 @@ entity AmcCarrierCoreBase is
       ASYNC_G                : boolean  := true;
       FSBL_G                 : boolean  := false;  -- false = Normal Operation, true = First Stage Boot loader
       APP_TYPE_G             : AppType;
-      WAVEFORM_TDATA_BYTES_G : positive := 4;
+      WAVEFORM_NUM_LANES_G   : positive := 4;  -- Number of Waveform lanes per DaqMuxV2
+      WAVEFORM_TDATA_BYTES_G : positive := 4;  -- Waveform stream's tData width (in units of bytes)
       ETH_USR_FRAME_LIMIT_G  : positive := 4096;   -- 4kB  
       MPS_SLOT_G             : boolean  := false);  -- false = Normal Operation, true = MPS message concentrator (Slot#2 only)      
    port (
@@ -397,6 +398,7 @@ begin
    U_Core : entity work.AmcCarrierCore
       generic map (
          TPD_G                  => TPD_G,
+         WAVEFORM_NUM_LANES_G   => WAVEFORM_NUM_LANES_G,
          WAVEFORM_TDATA_BYTES_G => WAVEFORM_TDATA_BYTES_G,
          ETH_USR_FRAME_LIMIT_G  => ETH_USR_FRAME_LIMIT_G,
          RSSI_ILEAVE_EN_G       => RSSI_ILEAVE_EN_G,

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCoreBase.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCoreBase.vhd
@@ -1,8 +1,6 @@
 -------------------------------------------------------------------------------
 -- File       : AmcCarrierCoreBase.vhd
 -- Company    : SLAC National Accelerator Laboratory
--- Created    : 2017-02-04
--- Last update: 2018-08-24
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -107,7 +105,7 @@ entity AmcCarrierCoreBase is
       recTimingRst         : out   sl;
       gthFabClk            : out   sl;
       stableClk            : out   sl;
-      stableRst            : out   sl;      
+      stableRst            : out   sl;
       -- Misc. Interface (axilClk domain)
       ipmiBsi              : out   BsiBusType;
       ethPhyReady          : out   sl;
@@ -156,6 +154,9 @@ entity AmcCarrierCoreBase is
       -- Configuration PROM Ports
       calScl               : inout sl;
       calSda               : inout sl;
+      -- VCCINT DC/DC Ports
+      pwrScl               : inout sl                               := 'Z';
+      pwrSda               : inout sl                               := 'Z';
       -- DDR3L SO-DIMM Ports
       ddrClkP              : in    sl;
       ddrClkN              : in    sl;
@@ -220,7 +221,7 @@ architecture mapping of AmcCarrierCoreBase is
    signal ddrMemError       : sl;
    --  MPS Interface
    signal mpsReadMaster     : AxiLiteReadMasterType;
-   signal mpsReadSlave      : AxiLiteReadSlaveType := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
+   signal mpsReadSlave      : AxiLiteReadSlaveType  := AXI_LITE_READ_SLAVE_EMPTY_DECERR_C;
    signal mpsWriteMaster    : AxiLiteWriteMasterType;
    signal mpsWriteSlave     : AxiLiteWriteSlaveType := AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C;
 
@@ -316,6 +317,9 @@ begin
          -- Configuration PROM Ports
          calScl            => calScl,
          calSda            => calSda,
+         -- VCCINT DC/DC Ports
+         pwrScl            => pwrScl,
+         pwrSda            => pwrSda,
          -- Clock Cleaner Ports
          timingClkScl      => timingClkScl,
          timingClkSda      => timingClkSda,
@@ -329,7 +333,7 @@ begin
 --   ------------------
 --   -- Application MPS
 --   ------------------
-   GEN_EN_MPS : if ( DISABLE_MPS_G = false ) generate
+   GEN_EN_MPS : if (DISABLE_MPS_G = false) generate
       U_AppMps : entity work.AppMps
          generic map (
             TPD_G      => TPD_G,
@@ -372,7 +376,7 @@ begin
             mpsTxN          => mpsTxN);
    end generate GEN_EN_MPS;
 
-   GEN_DIS_MPS : if ( DISABLE_MPS_G = true ) generate
+   GEN_DIS_MPS : if (DISABLE_MPS_G = true) generate
       mpsObMasters <= (others => AXI_STREAM_MASTER_INIT_C);
       mpsClkOut    <= '0';
       U_OBUFDS : OBUFDS

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCoreBase.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCoreBase.vhd
@@ -44,6 +44,11 @@ entity AmcCarrierCoreBase is
       DISABLE_TIME_GT_G      : boolean  := false;  -- false = normal application, true = doesn't build the Timing GT
       CORE_TRIGGERS_G        : positive := 16;
       TRIG_PIPE_G            : natural  := 0;  -- no trigger pipeline by default
+      USE_TPGMINI_G          : boolean  := true;   -- Build TPG Mini by default
+      CLKSEL_MODE_G          : string   := "SELECT"; -- "LCLSI","LCLSII"
+      STREAM_L1_G            : boolean  := true;
+      AXIL_RINGB_G           : boolean  := true;
+      ASYNC_G                : boolean  := true;
       FSBL_G                 : boolean  := false;  -- false = Normal Operation, true = First Stage Boot loader
       APP_TYPE_G             : AppType;
       WAVEFORM_TDATA_BYTES_G : positive := 4;
@@ -405,6 +410,11 @@ begin
          DISABLE_TIME_GT_G      => DISABLE_TIME_GT_G,
          CORE_TRIGGERS_G        => CORE_TRIGGERS_G,
          TRIG_PIPE_G            => TRIG_PIPE_G,
+         USE_TPGMINI_G          => USE_TPGMINI_G,
+	 STREAM_L1_G            => STREAM_L1_G,
+	 CLKSEL_MODE_G          => CLKSEL_MODE_G,
+	 AXIL_RINGB_G           => AXIL_RINGB_G,
+	 ASYNC_G                => ASYNC_G,
          FSBL_G                 => FSBL_G)
       port map (
          -----------------------

--- a/AmcCarrierCore/non-fsbl/AmcCarrierRssi.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierRssi.vhd
@@ -70,8 +70,8 @@ architecture mapping of AmcCarrierRssi is
    constant MAX_CUM_ACK_CNT_C  : positive := WINDOW_ADDR_SIZE_C;
    constant MAX_RETRANS_CNT_C  : positive := ite((WINDOW_ADDR_SIZE_C > 1), WINDOW_ADDR_SIZE_C-1, 1);
 
-   constant APP_AXIS_CONFIG_C  : AxiStreamConfigArray(4 downto 0) := (others => ETH_AXIS_CONFIG_C);
-   constant TEMP_AXIS_CONFIG_C : AxiStreamConfigArray(1 downto 0) := (others => ETH_AXIS_CONFIG_C);
+   constant APP_AXIS_CONFIG_C  : AxiStreamConfigArray(4 downto 0) := (others => AXIS_8BYTE_CONFIG_C);
+   constant TEMP_AXIS_CONFIG_C : AxiStreamConfigArray(1 downto 0) := (others => AXIS_8BYTE_CONFIG_C);
 
    signal rssiIbMasters : AxiStreamMasterArray(4 downto 0);
    signal rssiIbSlaves  : AxiStreamSlaveArray(4 downto 0);
@@ -182,7 +182,7 @@ begin
          SLAVE_READY_EN_G    => true,
          GEN_SYNC_FIFO_G     => true,
          TX_VALID_THOLD_G    => 256,  -- Pre-cache threshold set 256 out of 512 (prevent holding the ETH link during AXI-lite transactions)
-         AXI_STREAM_CONFIG_G => ETH_AXIS_CONFIG_C)
+         AXI_STREAM_CONFIG_G => AXIS_8BYTE_CONFIG_C)
       port map (
          -- AXIS Slave Interface (sAxisClk domain)
          sAxisClk         => axilClk,
@@ -235,12 +235,12 @@ begin
          EN_TIMEOUT_G        => true,
          MAXIS_CLK_FREQ_G    => AXI_CLK_FREQ_C,
          TIMEOUT_G           => TIMEOUT_C,
-         FRAME_LIMIT_G       => (ETH_USR_FRAME_LIMIT_G/8),  -- ETH_AXIS_CONFIG_C is 64-bit, FRAME_LIMIT_G is in units of ETH_AXIS_CONFIG_C.TDATA_BYTES_C
+         FRAME_LIMIT_G       => (ETH_USR_FRAME_LIMIT_G/8),  -- AXIS_8BYTE_CONFIG_C is 64-bit, FRAME_LIMIT_G is in units of AXIS_8BYTE_CONFIG_C.TDATA_BYTES_C
          COMMON_CLK_G        => true,
          SLAVE_FIFO_G        => false,
          MASTER_FIFO_G       => false,
-         SLAVE_AXI_CONFIG_G  => ETH_AXIS_CONFIG_C,
-         MASTER_AXI_CONFIG_G => ETH_AXIS_CONFIG_C)
+         SLAVE_AXI_CONFIG_G  => AXIS_8BYTE_CONFIG_C,
+         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
       port map (
          -- Slave Port
          sAxisClk    => axilClk,

--- a/AmcCarrierCore/non-fsbl/AmcCarrierRssi.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierRssi.vhd
@@ -99,6 +99,9 @@ architecture mapping of AmcCarrierRssi is
    signal tempObMasters : AxiStreamMasterArray(1 downto 0);
    signal tempObSlaves  : AxiStreamSlaveArray(1 downto 0);
 
+   signal obRssiTspMasters : AxiStreamMasterArray(1 downto 0);
+   signal obRssiTspSlaves  : AxiStreamSlaveArray(1 downto 0);
+
 begin
 
    --------------------------
@@ -159,8 +162,8 @@ begin
          -- Transport Layer Interface
          sTspAxisMaster_i  => obServerMasters(0),
          sTspAxisSlave_o   => obServerSlaves(0),
-         mTspAxisMaster_o  => ibServerMasters(0),
-         mTspAxisSlave_i   => ibServerSlaves(0),
+         mTspAxisMaster_o  => obRssiTspMasters(0),
+         mTspAxisSlave_i   => obRssiTspSlaves(0),
          -- High level  Application side interface
          openRq_i          => '1',  -- Automatically start the connection without debug SRP channel
          closeRq_i         => '0',
@@ -172,6 +175,20 @@ begin
          axilReadSlave     => axilReadSlaves(0),
          axilWriteMaster   => axilWriteMasters(0),
          axilWriteSlave    => axilWriteSlaves(0));
+         
+   U_RssiTspObFifo_0 : entity work.AmcCarrierRssiObFifo
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         -- Clock and Reset
+         axilClk         => axilClk,
+         axilRst         => axilRst,
+         -- RSSI Interface
+         obRssiTspMaster => obRssiTspMasters(0),
+         obRssiTspSlave  => obRssiTspSlaves(0),
+         -- Interface to UDP Server engine
+         ibServerMaster  => ibServerMasters(0),
+         ibServerSlave   => ibServerSlaves(0));          
 
    ------------------------------------------------
    -- AXI-Lite Master with RSSI Server: TDEST = 0x0
@@ -287,8 +304,8 @@ begin
          -- Transport Layer Interface
          sTspAxisMaster_i  => obServerMasters(1),
          sTspAxisSlave_o   => obServerSlaves(1),
-         mTspAxisMaster_o  => ibServerMasters(1),
-         mTspAxisSlave_i   => ibServerSlaves(1),
+         mTspAxisMaster_o  => obRssiTspMasters(1),
+         mTspAxisSlave_i   => obRssiTspSlaves(1),
          -- High level  Application side interface
          openRq_i          => '1',  -- Automatically start the connection without debug SRP channel
          closeRq_i         => '0',
@@ -300,6 +317,20 @@ begin
          axilReadSlave     => axilReadSlaves(1),
          axilWriteMaster   => axilWriteMasters(1),
          axilWriteSlave    => axilWriteSlaves(1));
+
+   U_RssiTspObFifo_1 : entity work.AmcCarrierRssiObFifo
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         -- Clock and Reset
+         axilClk         => axilClk,
+         axilRst         => axilRst,
+         -- RSSI Interface
+         obRssiTspMaster => obRssiTspMasters(1),
+         obRssiTspSlave  => obRssiTspSlaves(1),
+         -- Interface to UDP Server engine
+         ibServerMaster  => ibServerMasters(1),
+         ibServerSlave   => ibServerSlaves(1));  
 
    -----------------------------
    -- Memory Access: TDEST = 0x4

--- a/AmcCarrierCore/non-fsbl/AmcCarrierRssi.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierRssi.vhd
@@ -178,7 +178,8 @@ begin
          
    U_RssiTspObFifo_0 : entity work.AmcCarrierRssiObFifo
       generic map (
-         TPD_G => TPD_G)
+         TPD_G    => TPD_G,
+         BYPASS_G => true) -- true to reduce logic footprint
       port map (
          -- Clock and Reset
          axilClk         => axilClk,
@@ -320,7 +321,8 @@ begin
 
    U_RssiTspObFifo_1 : entity work.AmcCarrierRssiObFifo
       generic map (
-         TPD_G => TPD_G)
+         TPD_G    => TPD_G,
+         BYPASS_G => true) -- true to reduce logic footprint
       port map (
          -- Clock and Reset
          axilClk         => axilClk,

--- a/AmcCarrierCore/non-fsbl/AmcCarrierRssiInterleave.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierRssiInterleave.vhd
@@ -82,6 +82,9 @@ architecture mapping of AmcCarrierRssiInterleave is
    signal rssiObMasters : AxiStreamMasterArray(APP_STREAMS_C-1 downto 0);
    signal rssiObSlaves  : AxiStreamSlaveArray(APP_STREAMS_C-1 downto 0);
 
+   signal obRssiTspMaster : AxiStreamMasterType;
+   signal obRssiTspSlave  : AxiStreamSlaveType;
+
 begin
 
    -------------------------
@@ -126,8 +129,8 @@ begin
          -- Transport Layer Interface
          sTspAxisMaster_i  => obServerMaster,
          sTspAxisSlave_o   => obServerSlave,
-         mTspAxisMaster_o  => ibServerMaster,
-         mTspAxisSlave_i   => ibServerSlave,
+         mTspAxisMaster_o  => obRssiTspMaster,
+         mTspAxisSlave_i   => obRssiTspSlave,
          -- High level  Application side interface
          openRq_i          => '1',  -- Automatically start the connection without debug SRP channel
          closeRq_i         => '0',
@@ -139,6 +142,20 @@ begin
          axilReadSlave     => axilReadSlave,
          axilWriteMaster   => axilWriteMaster,
          axilWriteSlave    => axilWriteSlave);
+         
+   U_RssiTspObFifo : entity work.AmcCarrierRssiObFifo
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         -- Clock and Reset
+         axilClk         => axilClk,
+         axilRst         => axilRst,
+         -- RSSI Interface
+         obRssiTspMaster => obRssiTspMaster,
+         obRssiTspSlave  => obRssiTspSlave,
+         -- Interface to UDP Server engine
+         ibServerMaster  => ibServerMaster,
+         ibServerSlave   => ibServerSlave);         
 
    ------------------------------------------------
    -- AXI-Lite Master with RSSI Server: TDEST = 0x0

--- a/AmcCarrierCore/non-fsbl/AmcCarrierRssiInterleave.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierRssiInterleave.vhd
@@ -145,7 +145,8 @@ begin
          
    U_RssiTspObFifo : entity work.AmcCarrierRssiObFifo
       generic map (
-         TPD_G => TPD_G)
+         TPD_G    => TPD_G,
+         BYPASS_G => false)
       port map (
          -- Clock and Reset
          axilClk         => axilClk,

--- a/AmcCarrierCore/non-fsbl/AmcCarrierRssiInterleave.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierRssiInterleave.vhd
@@ -68,7 +68,7 @@ architecture mapping of AmcCarrierRssiInterleave is
    constant WINDOW_ADDR_SIZE_C : positive := 4;       -- 16 buffers (2^4)
    constant MAX_SEG_SIZE_C     : positive := 8192;    -- Jumbo frame chucking
 
-   constant APP_AXIS_CONFIG_C : AxiStreamConfigArray(APP_STREAMS_C-1 downto 0) := (others => ETH_AXIS_CONFIG_C);
+   constant APP_AXIS_CONFIG_C : AxiStreamConfigArray(APP_STREAMS_C-1 downto 0) := (others => AXIS_8BYTE_CONFIG_C);
 
    constant SRP_IDX_C        : natural := 0;
    constant BSA_ASYNC_IDX_C  : natural := 1;
@@ -148,7 +148,7 @@ begin
          TPD_G               => TPD_G,
          SLAVE_READY_EN_G    => true,
          GEN_SYNC_FIFO_G     => true,
-         AXI_STREAM_CONFIG_G => ETH_AXIS_CONFIG_C)
+         AXI_STREAM_CONFIG_G => AXIS_8BYTE_CONFIG_C)
       port map (
          -- AXIS Slave Interface (sAxisClk domain)
          sAxisClk         => axilClk,
@@ -211,12 +211,12 @@ begin
          EN_TIMEOUT_G        => true,
          MAXIS_CLK_FREQ_G    => AXI_CLK_FREQ_C,
          TIMEOUT_G           => TIMEOUT_C,
-         FRAME_LIMIT_G       => (ETH_USR_FRAME_LIMIT_G/8),  -- ETH_AXIS_CONFIG_C is 64-bit, FRAME_LIMIT_G is in units of ETH_AXIS_CONFIG_C.TDATA_BYTES_C
+         FRAME_LIMIT_G       => (ETH_USR_FRAME_LIMIT_G/8),  -- AXIS_8BYTE_CONFIG_C is 64-bit, FRAME_LIMIT_G is in units of AXIS_8BYTE_CONFIG_C.TDATA_BYTES_C
          COMMON_CLK_G        => true,
          SLAVE_FIFO_G        => false,
          MASTER_FIFO_G       => false,
-         SLAVE_AXI_CONFIG_G  => ETH_AXIS_CONFIG_C,
-         MASTER_AXI_CONFIG_G => ETH_AXIS_CONFIG_C)
+         SLAVE_AXI_CONFIG_G  => AXIS_8BYTE_CONFIG_C,
+         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
       port map (
          -- Slave Port
          sAxisClk    => axilClk,

--- a/AmcCarrierCore/non-fsbl/AmcCarrierRssiObFifo.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierRssiObFifo.vhd
@@ -1,0 +1,103 @@
+-------------------------------------------------------------------------------
+-- File       : AmcCarrierRssiObFifo.vhd
+-- Company    : SLAC National Accelerator Laboratory
+-------------------------------------------------------------------------------
+-- Description: Adds a "store + forwarding" FIFO and throttling of the RSSI TSP outbound interface
+-------------------------------------------------------------------------------
+-- This file is part of 'LCLS2 Common Carrier Core'.
+-- It is subject to the license terms in the LICENSE.txt file found in the 
+-- top-level directory of this distribution and at: 
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+-- No part of 'LCLS2 Common Carrier Core', including this file, 
+-- may be copied, modified, propagated, or distributed except according to 
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_unsigned.all;
+use ieee.std_logic_arith.all;
+
+use work.StdRtlPkg.all;
+use work.AxiStreamPkg.all;
+use work.EthMacPkg.all;
+
+entity AmcCarrierRssiObFifo is
+   generic (
+      TPD_G : time := 1 ns);
+   port (
+      -- Clock and Reset
+      axilClk         : in  sl;
+      axilRst         : in  sl;
+      -- RSSI Interface
+      obRssiTspMaster : in  AxiStreamMasterType;
+      obRssiTspSlave  : out AxiStreamSlaveType;
+      -- Interface to UDP Server engine
+      ibServerMaster  : out AxiStreamMasterType;
+      ibServerSlave   : in  AxiStreamSlaveType);
+end AmcCarrierRssiObFifo;
+
+architecture mapping of AmcCarrierRssiObFifo is
+
+   constant AXIS_CONFIG_C : AxiStreamConfigType := (
+      TSTRB_EN_C    => EMAC_AXIS_CONFIG_C.TSTRB_EN_C,
+      TDATA_BYTES_C => 2,  -- 2Bytes x 156.25 MHz x 8b/B = 2.5 Gb/s throttle 
+      TDEST_BITS_C  => EMAC_AXIS_CONFIG_C.TDEST_BITS_C,
+      TID_BITS_C    => EMAC_AXIS_CONFIG_C.TID_BITS_C,
+      TKEEP_MODE_C  => EMAC_AXIS_CONFIG_C.TKEEP_MODE_C,
+      TUSER_BITS_C  => EMAC_AXIS_CONFIG_C.TUSER_BITS_C,
+      TUSER_MODE_C  => EMAC_AXIS_CONFIG_C.TUSER_MODE_C);
+
+   signal chokeMaster : AxiStreamMasterType;
+   signal chokeSlave  : AxiStreamSlaveType;
+
+begin
+
+   U_Choke : entity work.AxiStreamResize
+      generic map (
+         -- General Configurations
+         TPD_G               => TPD_G,
+         READY_EN_G          => true,
+         -- AXI Stream Port Configurations
+         SLAVE_AXI_CONFIG_G  => EMAC_AXIS_CONFIG_C,
+         MASTER_AXI_CONFIG_G => AXIS_CONFIG_C)
+      port map (
+         -- Clock and reset
+         axisClk     => axilClk,
+         axisRst     => axilRst,
+         -- Slave Port
+         sAxisMaster => obRssiTspMaster,
+         sAxisSlave  => obRssiTspSlave,
+         -- Master Port
+         mAxisMaster => chokeMaster,
+         mAxisSlave  => chokeSlave);
+
+   U_Burst_Fifo : entity work.AxiStreamFifoV2
+      generic map (
+         -- General Configurations
+         TPD_G               => TPD_G,
+         PIPE_STAGES_G       => 1,
+         SLAVE_READY_EN_G    => true,
+         VALID_THOLD_G       => 0,      -- 0 = "store and forward"
+         -- FIFO configurations
+         BRAM_EN_G           => true,
+         GEN_SYNC_FIFO_G     => true,
+         INT_WIDTH_SELECT_G  => "CUSTOM",  -- Force internal width
+         INT_DATA_WIDTH_G    => 16,     -- 128-bit         
+         FIFO_ADDR_WIDTH_G   => 10,  -- 16kB/FIFO = 128-bits x 1024 entries         
+         -- AXI Stream Port Configurations
+         SLAVE_AXI_CONFIG_G  => AXIS_CONFIG_C,
+         MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C)
+      port map (
+         -- Slave Port
+         sAxisClk    => axilClk,
+         sAxisRst    => axilRst,
+         sAxisMaster => chokeMaster,
+         sAxisSlave  => chokeSlave,
+         -- Master Port
+         mAxisClk    => axilClk,
+         mAxisRst    => axilRst,
+         mAxisMaster => ibServerMaster,
+         mAxisSlave  => ibServerSlave);
+
+end mapping;

--- a/AmcCarrierCore/non-fsbl/AmcCarrierRssiObFifo.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierRssiObFifo.vhd
@@ -55,8 +55,8 @@ architecture mapping of AmcCarrierRssiObFifo is
 begin
 
    BYPASS_LOGIC : if (BYPASS_G = true) generate
-      ddrObMasters <= ddrIbMasters;
-      ddrIbSlaves  <= ddrObSlaves;
+      ibServerMaster  <= obRssiTspMaster;
+      obRssiTspSlave  <= ibServerSlave;
    end generate;
 
    BUILD_LOGIC : if (BYPASS_G = false) generate

--- a/AmcCarrierCore/xdc/kintexuplus/AmcCarrierAppPorts.xdc
+++ b/AmcCarrierCore/xdc/kintexuplus/AmcCarrierAppPorts.xdc
@@ -69,6 +69,10 @@ set_property -dict { PACKAGE_PIN AD8 IOSTANDARD LVCMOS25 } [get_ports {ipmcSda}]
 set_property -dict { PACKAGE_PIN AM12 IOSTANDARD LVCMOS25 } [get_ports {calScl}]
 set_property -dict { PACKAGE_PIN AN12 IOSTANDARD LVCMOS25 } [get_ports {calSda}]
 
+# VCCINT DC/DC Ports
+set_property -dict { PACKAGE_PIN AA34 IOSTANDARD LVCMOS18 } [get_ports {pwrScl}]
+set_property -dict { PACKAGE_PIN AB34 IOSTANDARD LVCMOS18 } [get_ports {pwrSda}]
+
 # DDR3L SO-DIMM Ports
 set_property -dict { PACKAGE_PIN K20 IOSTANDARD LVCMOS15 } [get_ports {ddrScl}] 
 set_property -dict { PACKAGE_PIN K21 IOSTANDARD LVCMOS15 } [get_ports {ddrSda}] 

--- a/AmcCarrierCore/yaml/AmcCarrierCore.yaml
+++ b/AmcCarrierCore/yaml/AmcCarrierCore.yaml
@@ -117,10 +117,10 @@ AmcCarrierCore: &AmcCarrierCore
           sizeBits: 32
       instantiate: false          
    ##################################################
-    AxiCdcm6208:
-      <<: *AxiCdcm6208
-      at:
-        offset: 0x05000000
+    # AxiCdcm6208:
+      # <<: *AxiCdcm6208
+      # at:
+        # offset: 0x05000000
     ##################################################
     DdrSpd:
       at:

--- a/AmcCarrierCore/yaml/AmcCarrierCore.yaml
+++ b/AmcCarrierCore/yaml/AmcCarrierCore.yaml
@@ -101,42 +101,42 @@ AmcCarrierCore: &AmcCarrierCore
         OutputConfig[3] = 0x3: Connects Backplane DIST1 to RTM_TIMING_IN1
         -----------------------------------------------------------------
     ##################################################
-    Axi24LC64FT:
-      at:
-        offset: 0x04000000
-      class: MMIODev
-      size: 0x2000
-      description: AMC Carrier core's Non-volatile memory (100k endurance)
-      children:
-        MemoryArray:
-          <<: *MemoryArray
-          at:
-            offset: 0x0
-            nelms: 0x800
-            stride: 4
-          sizeBits: 32
-      instantiate: false          
+    # Axi24LC64FT:
+      # at:
+        # offset: 0x04000000
+      # class: MMIODev
+      # size: 0x2000
+      # description: AMC Carrier core's Non-volatile memory (100k endurance)
+      # children:
+        # MemoryArray:
+          # <<: *MemoryArray
+          # at:
+            # offset: 0x0
+            # nelms: 0x800
+            # stride: 4
+          # sizeBits: 32
+      # instantiate: false          
    ##################################################
     # AxiCdcm6208:
       # <<: *AxiCdcm6208
       # at:
         # offset: 0x05000000
     ##################################################
-    DdrSpd:
-      at:
-        offset: 0x06000000
-      size: 0x400
-      class: MMIODev
-      description: Lookup tool at www.micron.com/spd
-      children:
-        MemoryArray:
-          <<: *MemoryArray
-          at:
-            offset: 0x0
-            nelms: 0x100
-            stride: 4
-          sizeBits: 8
-          mode: RO # Read only
+    # DdrSpd:
+      # at:
+        # offset: 0x06000000
+      # size: 0x400
+      # class: MMIODev
+      # description: Lookup tool at www.micron.com/spd
+      # children:
+        # MemoryArray:
+          # <<: *MemoryArray
+          # at:
+            # offset: 0x0
+            # nelms: 0x100
+            # stride: 4
+          # sizeBits: 8
+          # mode: RO # Read only
     ##################################################
     AmcCarrierBsi:
       <<: *AmcCarrierBsi

--- a/AppHardware/AmcCryo/rtl/AmcCryoCore.vhd
+++ b/AppHardware/AmcCryo/rtl/AmcCryoCore.vhd
@@ -1,8 +1,6 @@
 -------------------------------------------------------------------------------
 -- File       : AmcCryoCore.vhd
 -- Company    : SLAC National Accelerator Laboratory
--- Created    : 2017-10-05
--- Last update: 2018-03-14
 -------------------------------------------------------------------------------
 -- Description: https://confluence.slac.stanford.edu/display/AIRTRACK/PC_379_396_23_C00
 -------------------------------------------------------------------------------
@@ -266,39 +264,70 @@ begin
    ----------------------------------------------------------------
    -- JESD Buffers
    ----------------------------------------------------------------
-   IBUFDS_SysRef : IBUFDS
+   U_jesdSysRef : entity work.JesdSyncIn
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => true)  -- Note inverted because it is Swapped on the board
       port map (
-         I  => jesdSysRefP,
-         IB => jesdSysRefN,
-         O  => s_jesdSysRef);
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Ports
+         jesdSyncP => jesdSysRefP,
+         jesdSyncN => jesdSysRefN,
+         -- JESD Low speed Interface
+         jesdSync  => jesdSysRef);
 
-   jesdSysRef <= not(s_jesdSysRef);  -- Note inverted because it is Swapped on the board
-
-   OBUFDS0_RxSync : OBUFDS
+   U_jesdRxSync0 : entity work.JesdSyncOut
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdRxSync,
-         O  => jesdRxSyncP(0),
-         OB => jesdRxSyncN(0));
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Interface
+         jesdSync  => jesdRxSync,
+         -- JESD Low speed Ports
+         jesdSyncP => jesdRxSyncP(0),
+         jesdSyncN => jesdRxSyncN(0));
 
-   jesdRxSyncL <= not(jesdRxSync);  -- Note inverted because it is Swapped on the board
-
-   OBUFDS1_RxSync : OBUFDS
+   U_jesdRxSync1 : entity work.JesdSyncOut
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => true)  -- Note inverted because it is Swapped on the board
       port map (
-         I  => jesdRxSyncL,
-         O  => jesdRxSyncP(1),
-         OB => jesdRxSyncN(1));
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Interface
+         jesdSync  => jesdRxSync,
+         -- JESD Low speed Ports
+         jesdSyncP => jesdRxSyncP(1),
+         jesdSyncN => jesdRxSyncN(1));
 
-   IBUFDS0_TxSync : IBUFDS
+   U_jesdTxSync0 : entity work.JesdSyncIn
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdTxSyncP(0),
-         IB => jesdTxSyncN(0),
-         O  => jesdTxSyncRaw(0));
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Ports
+         jesdSyncP => jesdTxSyncP(0),
+         jesdSyncN => jesdTxSyncN(0),
+         -- JESD Low speed Interface
+         jesdSync  => jesdTxSyncRaw(0));
 
-   IBUFDS1_TxSync : IBUFDS
+   U_jesdTxSync1 : entity work.JesdSyncIn
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdTxSyncP(1),
-         IB => jesdTxSyncN(1),
-         O  => jesdTxSyncRaw(1));
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Ports
+         jesdSyncP => jesdTxSyncP(1),
+         jesdSyncN => jesdTxSyncN(1),
+         -- JESD Low speed Interface
+         jesdSync  => jesdTxSyncRaw(1));
 
    jesdTxSyncVec(0) <= jesdTxSyncMask(0) or not(jesdTxSyncRaw(0));
    jesdTxSyncVec(1) <= jesdTxSyncMask(1) or jesdTxSyncRaw(1);

--- a/AppHardware/AmcCryoDemo/rtl/AmcCryoDemoCore.vhd
+++ b/AppHardware/AmcCryoDemo/rtl/AmcCryoDemoCore.vhd
@@ -1,8 +1,6 @@
 -------------------------------------------------------------------------------
 -- File       : AmcCryoDemoCore.vhd
 -- Company    : SLAC National Accelerator Laboratory
--- Created    : 2017-09-09
--- Last update: 2018-03-14
 -------------------------------------------------------------------------------
 -- Description: https://confluence.slac.stanford.edu/display/AIRTRACK/PC_379_396_02_C00
 -------------------------------------------------------------------------------
@@ -225,26 +223,47 @@ begin
    ----------------------------------------------------------------
    -- JESD Buffers
    ----------------------------------------------------------------
-   IBUFDS_SysRef : IBUFDS
+   U_jesdSysRef : entity work.JesdSyncIn
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdSysRefP,
-         IB => jesdSysRefN,
-         O  => jesdSysRef);
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Ports
+         jesdSyncP => jesdSysRefP,
+         jesdSyncN => jesdSysRefN,
+         -- JESD Low speed Interface
+         jesdSync  => jesdSysRef);
 
    GEN_RX_SYNC :
    for i in 2 downto 0 generate
-      OBUFDS_RxSync : OBUFDS
+      U_jesdRxSync : entity work.JesdSyncOut
+         generic map (
+            TPD_G    => TPD_G,
+            INVERT_G => false)
          port map (
-            I  => jesdRxSync,
-            O  => jesdRxSyncP(i),
-            OB => jesdRxSyncN(i));
+            -- Clock
+            jesdClk   => jesdClk,
+            -- JESD Low speed Interface
+            jesdSync  => jesdRxSync,
+            -- JESD Low speed Ports
+            jesdSyncP => jesdRxSyncP(i),
+            jesdSyncN => jesdRxSyncN(i));
    end generate GEN_RX_SYNC;
 
-   IBUFDS_TxSync : IBUFDS
+   U_jesdTxSync : entity work.JesdSyncIn
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdTxSyncP,
-         IB => jesdTxSyncN,
-         O  => jesdTxSync);
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Ports
+         jesdSyncP => jesdTxSyncP,
+         jesdSyncN => jesdTxSyncN,
+         -- JESD Low speed Interface
+         jesdSync  => jesdTxSync);
 
    ----------------------------------------------------------------
    -- SPI interface ADCs and LMK 

--- a/AppHardware/AmcGenericAdcDac/rtl/AmcGenericAdcDacCore.vhd
+++ b/AppHardware/AmcGenericAdcDac/rtl/AmcGenericAdcDacCore.vhd
@@ -323,25 +323,46 @@ begin
 
    bcmL <= not(bcm);
 
-   IBUFDS_SysRef : IBUFDS
+   U_jesdSysRef : entity work.JesdSyncIn
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdSysRefP,
-         IB => jesdSysRefN,
-         O  => jesdSysRef);
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Ports
+         jesdSyncP => jesdSysRefP,
+         jesdSyncN => jesdSysRefN,
+         -- JESD Low speed Interface
+         jesdSync  => jesdSysRef);
 
-   IBUFDS_TxSync : IBUFDS
+   U_jesdTxSync : entity work.JesdSyncIn
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdTxSyncP,
-         IB => jesdTxSyncN,
-         O  => jesdTxSync);
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Ports
+         jesdSyncP => jesdTxSyncP,
+         jesdSyncN => jesdTxSyncN,
+         -- JESD Low speed Interface
+         jesdSync  => jesdTxSync);
 
    GEN_RX_SYNC :
    for i in 1 downto 0 generate
-      OBUFDS_RxSync : OBUFDS
+      U_jesdRxSync : entity work.JesdSyncOut
+         generic map (
+            TPD_G    => TPD_G,
+            INVERT_G => false)
          port map (
-            I  => jesdRxSync,
-            O  => jesdRxSyncP(i),
-            OB => jesdRxSyncN(i));
+            -- Clock
+            jesdClk   => jesdClk,
+            -- JESD Low speed Interface
+            jesdSync  => jesdRxSync,
+            -- JESD Low speed Ports
+            jesdSyncP => jesdRxSyncP(i),
+            jesdSyncN => jesdRxSyncN(i));
    end generate GEN_RX_SYNC;
 
    ---------------------

--- a/AppHardware/AmcMrLlrfDownConvert/core/AmcMrLlrfDownConvertCore.vhd
+++ b/AppHardware/AmcMrLlrfDownConvert/core/AmcMrLlrfDownConvertCore.vhd
@@ -1,8 +1,6 @@
 -------------------------------------------------------------------------------
 -- File       : AmcMrLlrfDownConvertCore.vhd
 -- Company    : SLAC National Accelerator Laboratory
--- Created    : 2015-12-07
--- Last update: 2018-03-14
 -------------------------------------------------------------------------------
 -- Description: https://confluence.slac.stanford.edu/display/AIRTRACK/PC_379_396_16_C02
 -------------------------------------------------------------------------------
@@ -79,30 +77,30 @@ end AmcMrLlrfDownConvertCore;
 architecture mapping of AmcMrLlrfDownConvertCore is
 
    constant I2C_DEVICE_MAP_C : I2cAxiLiteDevArray(0 to 3) := (
-      0             => MakeI2cAxiLiteDevType(
-         i2cAddress => "1001000",       -- ADT7420: A1=GND,A0=GND
-         dataSize   => 8,               -- in units of bits
-         addrSize   => 8,               -- in units of bits
-         endianness => '1',             -- Big endian
-         repeatStart=> '1'),            -- Enable repeated start
-      1             => MakeI2cAxiLiteDevType(
-         i2cAddress => "1001001",       -- ADT7420: A1=GND,A0=VDD
-         dataSize   => 8,               -- in units of bits
-         addrSize   => 8,               -- in units of bits
-         endianness => '1',             -- Big endian
-         repeatStart=> '1'),            -- Enable repeated start
-      2             => MakeI2cAxiLiteDevType(
-         i2cAddress => "1001010",       -- ADT7420: A1=VDD,A0=GND
-         dataSize   => 8,               -- in units of bits
-         addrSize   => 8,               -- in units of bits
-         endianness => '1',             -- Big endian
-         repeatStart=> '1'),            -- Enable repeated start
-      3             => MakeI2cAxiLiteDevType(
-         i2cAddress => "1001011",       -- ADT7420: A1=VDD,A0=VDD
-         dataSize   => 8,               -- in units of bits
-         addrSize   => 8,               -- in units of bits
-         endianness => '1',             -- Big endian
-         repeatStart=> '1'));           -- Enable repeated start       
+      0              => MakeI2cAxiLiteDevType(
+         i2cAddress  => "1001000",      -- ADT7420: A1=GND,A0=GND
+         dataSize    => 8,              -- in units of bits
+         addrSize    => 8,              -- in units of bits
+         endianness  => '1',            -- Big endian
+         repeatStart => '1'),           -- Enable repeated start
+      1              => MakeI2cAxiLiteDevType(
+         i2cAddress  => "1001001",      -- ADT7420: A1=GND,A0=VDD
+         dataSize    => 8,              -- in units of bits
+         addrSize    => 8,              -- in units of bits
+         endianness  => '1',            -- Big endian
+         repeatStart => '1'),           -- Enable repeated start
+      2              => MakeI2cAxiLiteDevType(
+         i2cAddress  => "1001010",      -- ADT7420: A1=VDD,A0=GND
+         dataSize    => 8,              -- in units of bits
+         addrSize    => 8,              -- in units of bits
+         endianness  => '1',            -- Big endian
+         repeatStart => '1'),           -- Enable repeated start
+      3              => MakeI2cAxiLiteDevType(
+         i2cAddress  => "1001011",      -- ADT7420: A1=VDD,A0=VDD
+         dataSize    => 8,              -- in units of bits
+         addrSize    => 8,              -- in units of bits
+         endianness  => '1',            -- Big endian
+         repeatStart => '1'));          -- Enable repeated start       
 
    constant NUM_AXI_MASTERS_C      : natural  := 15;
    constant NUM_COMMON_SPI_CHIPS_C : positive := 4;
@@ -237,31 +235,57 @@ begin
    -----------------------
    -- Generalized Mapping 
    -----------------------
-   U_jesdSysRef : IBUFDS
+   U_jesdSysRef : entity work.JesdSyncIn
       generic map (
-         DIFF_TERM => true)
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => sysRefP(2),
-         IB => sysRefN(2),
-         O  => jesdSysRef);
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Ports
+         jesdSyncP => sysRefP(2),
+         jesdSyncN => sysRefN(2),
+         -- JESD Low speed Interface
+         jesdSync  => jesdSysRef);
 
-   U_jesdRxSync0 : OBUFDS
+   U_jesdRxSync0 : entity work.JesdSyncOut
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdRxSync,
-         O  => syncOutP(5),
-         OB => syncOutN(5));
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Interface
+         jesdSync  => jesdRxSync,
+         -- JESD Low speed Ports
+         jesdSyncP => syncOutP(5),
+         jesdSyncN => syncOutN(5));
 
-   U_jesdRxSync1 : OBUFDS
+   U_jesdRxSync1 : entity work.JesdSyncOut
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdRxSync,
-         O  => syncOutP(0),
-         OB => syncOutN(0));
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Interface
+         jesdSync  => jesdRxSync,
+         -- JESD Low speed Ports
+         jesdSyncP => syncOutP(0),
+         jesdSyncN => syncOutN(0));
 
-   U_jesdRxSync2 : OBUFDS
+   U_jesdRxSync2 : entity work.JesdSyncOut
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdRxSync,
-         O  => syncInP(1),
-         OB => syncInN(1));
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Interface
+         jesdSync  => jesdRxSync,
+         -- JESD Low speed Ports
+         jesdSyncP => syncInP(1),
+         jesdSyncN => syncInN(1));
 
    ADC_SDIO_IOBUFT : IOBUF
       port map (

--- a/AppHardware/AmcMrLlrfUpConvert/v1/AmcMrLlrfUpConvertMapping.vhd
+++ b/AppHardware/AmcMrLlrfUpConvert/v1/AmcMrLlrfUpConvertMapping.vhd
@@ -1,8 +1,6 @@
 -------------------------------------------------------------------------------
 -- File       : AmcMrLlrfUpConvertMapping.vhd
 -- Company    : SLAC National Accelerator Laboratory
--- Created    : 2017-03-30
--- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -86,31 +84,57 @@ begin
    -----------------------
    -- Generalized Mapping 
    -----------------------
-   U_jesdSysRef : IBUFDS
+   U_jesdSysRef : entity work.JesdSyncIn
       generic map (
-         DIFF_TERM => true)
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => syncOutP(7),
-         IB => syncOutN(7),
-         O  => jesdSysRef);
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Ports
+         jesdSyncP => syncOutP(7),
+         jesdSyncN => syncOutN(7),
+         -- JESD Low speed Interface
+         jesdSync  => jesdSysRef);
 
-   U_jesdRxSync0 : OBUFDS
+   U_jesdRxSync0 : entity work.JesdSyncOut
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdRxSync,
-         O  => syncOutP(4),
-         OB => syncOutN(4));
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Interface
+         jesdSync  => jesdRxSync,
+         -- JESD Low speed Ports
+         jesdSyncP => syncOutP(4),
+         jesdSyncN => syncOutN(4));
 
-   U_jesdRxSync1 : OBUFDS
+   U_jesdRxSync1 : entity work.JesdSyncOut
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdRxSync,
-         O  => syncOutP(2),
-         OB => syncOutN(2));
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Interface
+         jesdSync  => jesdRxSync,
+         -- JESD Low speed Ports
+         jesdSyncP => syncOutP(2),
+         jesdSyncN => syncOutN(2));
 
-   U_jesdRxSync2 : OBUFDS
+   U_jesdRxSync2 : entity work.JesdSyncOut
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdRxSync,
-         O  => syncOutP(1),
-         OB => syncOutN(1));
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Interface
+         jesdSync  => jesdRxSync,
+         -- JESD Low speed Ports
+         jesdSyncP => syncOutP(1),
+         jesdSyncN => syncOutN(1));
 
    ADC_SDIO_IOBUFT : IOBUF
       port map (
@@ -143,7 +167,7 @@ begin
    DATA_OUT : if (TIMING_TRIG_MODE_G = false) generate
       U_ODDR : ODDRE1
          generic map (
-            SIM_DEVICE => ite(ULTRASCALE_PLUS_C,"ULTRASCALE_PLUS","ULTRASCALE"))     
+            SIM_DEVICE => ite(ULTRASCALE_PLUS_C, "ULTRASCALE_PLUS", "ULTRASCALE"))
          port map (
             C  => recClk,
             Q  => timingTrigReg,

--- a/AppHardware/AmcMrLlrfUpConvert/v2/AmcMrLlrfUpConvertMapping.vhd
+++ b/AppHardware/AmcMrLlrfUpConvert/v2/AmcMrLlrfUpConvertMapping.vhd
@@ -1,8 +1,6 @@
 -------------------------------------------------------------------------------
 -- File       : AmcMrLlrfUpConvertMapping.vhd
 -- Company    : SLAC National Accelerator Laboratory
--- Created    : 2017-03-30
--- Last update: 2018-02-14
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -86,31 +84,57 @@ begin
    -----------------------
    -- Generalized Mapping 
    -----------------------
-   U_jesdSysRef : IBUFDS
+   U_jesdSysRef : entity work.JesdSyncIn
       generic map (
-         DIFF_TERM => true)
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => syncOutP(7),
-         IB => syncOutN(7),
-         O  => jesdSysRef);
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Ports
+         jesdSyncP => syncOutP(7),
+         jesdSyncN => syncOutN(7),
+         -- JESD Low speed Interface
+         jesdSync  => jesdSysRef);
 
-   U_jesdRxSync0 : OBUFDS
+   U_jesdRxSync0 : entity work.JesdSyncOut
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdRxSync,
-         O  => syncOutP(4),
-         OB => syncOutN(4));
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Interface
+         jesdSync  => jesdRxSync,
+         -- JESD Low speed Ports
+         jesdSyncP => syncOutP(4),
+         jesdSyncN => syncOutN(4));
 
-   U_jesdRxSync1 : OBUFDS
+   U_jesdRxSync1 : entity work.JesdSyncOut
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdRxSync,
-         O  => syncOutP(2),
-         OB => syncOutN(2));
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Interface
+         jesdSync  => jesdRxSync,
+         -- JESD Low speed Ports
+         jesdSyncP => syncOutP(2),
+         jesdSyncN => syncOutN(2));
 
-   U_jesdRxSync2 : OBUFDS
+   U_jesdRxSync2 : entity work.JesdSyncOut
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdRxSync,
-         O  => syncOutP(1),
-         OB => syncOutN(1));
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Interface
+         jesdSync  => jesdRxSync,
+         -- JESD Low speed Ports
+         jesdSyncP => syncOutP(1),
+         jesdSyncN => syncOutN(1));
 
    ADC_SDIO_IOBUFT : IOBUF
       port map (
@@ -143,7 +167,7 @@ begin
    DATA_OUT : if (TIMING_TRIG_MODE_G = false) generate
       U_ODDR : ODDRE1
          generic map (
-            SIM_DEVICE => ite(ULTRASCALE_PLUS_C,"ULTRASCALE_PLUS","ULTRASCALE"))     
+            SIM_DEVICE => ite(ULTRASCALE_PLUS_C, "ULTRASCALE_PLUS", "ULTRASCALE"))
          port map (
             C  => recClk,
             Q  => timingTrigReg,

--- a/AppHardware/AmcStriplineBpm/rtl/AmcStriplineBpmCore.vhd
+++ b/AppHardware/AmcStriplineBpm/rtl/AmcStriplineBpmCore.vhd
@@ -1,8 +1,6 @@
 -------------------------------------------------------------------------------
 -- File       : AmcStriplineBpmCore.vhd
 -- Company    : SLAC National Accelerator Laboratory
--- Created    : 2015-10-28
--- Last update: 2018-03-14
 -------------------------------------------------------------------------------
 -- Description: https://confluence.slac.stanford.edu/display/AIRTRACK/PC_379_396_03_CXX
 -------------------------------------------------------------------------------
@@ -242,23 +240,44 @@ begin
    spareN(9)   <= clClkOe;
    spareP(9)   <= rfAmpOn;
    -- JESD
-   IBUFDS_SysRef : IBUFDS
+   U_jesdSysRef : entity work.JesdSyncIn
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => fpgaClkP(0),
-         IB => fpgaClkN(0),
-         O  => jesdSysRef);
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Ports
+         jesdSyncP => fpgaClkP(0),
+         jesdSyncN => fpgaClkN(0),
+         -- JESD Low speed Interface
+         jesdSync  => jesdSysRef);
 
-   OBUFDS_RxSync0 : OBUFDS
+   U_jesdRxSync0 : entity work.JesdSyncOut
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdRxSync,
-         O  => jtagSec(0),
-         OB => jtagSec(1));
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Interface
+         jesdSync  => jesdRxSync,
+         -- JESD Low speed Ports
+         jesdSyncP => jtagSec(0),
+         jesdSyncN => jtagSec(1));
 
-   OBUFDS_RxSync1 : OBUFDS
+   U_jesdRxSync1 : entity work.JesdSyncOut
+      generic map (
+         TPD_G    => TPD_G,
+         INVERT_G => false)
       port map (
-         I  => jesdRxSync,
-         O  => jtagSec(2),
-         OB => jtagSec(3));
+         -- Clock
+         jesdClk   => jesdClk,
+         -- JESD Low speed Interface
+         jesdSync  => jesdRxSync,
+         -- JESD Low speed Ports
+         jesdSyncP => jtagSec(2),
+         jesdSyncN => jtagSec(3));
 
    -- Triggers
    IBUFDS_ExtTrig : IBUFDS

--- a/AppMps/xdc/MpsAppNodeKcu11p.xdc
+++ b/AppMps/xdc/MpsAppNodeKcu11p.xdc
@@ -12,18 +12,17 @@
 ## Area/Placement Constraints ##
 ################################
 
-# set_property LOC PLL_X0Y10 [get_cells {U_Core/GEN_EN_MPS.U_AppMps/U_Clk/U_MpsSerdesPll}]
+# set_property LOC PLL_X0Y4 [get_cells {U_Core/GEN_EN_MPS.U_AppMps/U_Clk/U_MpsSerdesPll}]
 
-# set_property LOC BUFGCE_X0Y123 [get_cells {U_Core/GEN_EN_MPS.U_AppMps/U_Clk/U_Bufg625}]
-# set_property LOC BUFGCE_X0Y127 [get_cells {U_Core/GEN_EN_MPS.U_AppMps/U_Clk/U_Bufg312}]
-# set_property LOC BUFGCE_X0Y133 [get_cells {U_Core/GEN_EN_MPS.U_AppMps/U_Clk/U_Bufg125}]
-# set_property LOC BUFGCE_X0Y132 [get_cells {U_Core/GEN_EN_MPS.U_AppMps/U_Clk/U_Bufg}]
+set_property LOC BUFGCE_X0Y50    [get_cells {U_Core/GEN_EN_MPS.U_AppMps/U_Clk/U_Bufg625}]
+set_property LOC BUFGCE_DIV_X0Y8 [get_cells {U_Core/GEN_EN_MPS.U_AppMps/U_Clk/U_Bufg312}]
+set_property LOC BUFGCE_X0Y49    [get_cells {U_Core/GEN_EN_MPS.U_AppMps/U_Clk/U_Bufg125}]
 
-# set_property LOC HPIOBDIFFOUTBUF_X0Y120 [get_cells {U_Core/GEN_EN_MPS.U_AppMps/U_Salt/APP_SLOT.U_SaltUltraScale/TX_ONLY.U_SaltUltraScaleCore/U0/lvds_transceiver_mw/serdes_10_to_1_ser8_i/io_data_out}]
-# set_property LOC BITSLICE_RX_TX_X0Y260  [get_cells {U_Core/GEN_EN_MPS.U_AppMps/U_Salt/APP_SLOT.U_SaltUltraScale/TX_ONLY.U_SaltUltraScaleCore/U0/lvds_transceiver_mw/serdes_10_to_1_ser8_i/oserdes_m}]
+set_property LOC HPIOBDIFFOUTBUF_X0Y144 [get_cells {U_Core/GEN_EN_MPS.U_AppMps/U_Salt/APP_SLOT.U_SaltUltraScale/TX_ONLY.U_SaltUltraScaleCore/U0/lvds_transceiver_mw/serdes_10_to_1_ser8_i/io_data_out}]
+set_property LOC BITSLICE_RX_TX_X0Y312  [get_cells {U_Core/GEN_EN_MPS.U_AppMps/U_Salt/APP_SLOT.U_SaltUltraScale/TX_ONLY.U_SaltUltraScaleCore/U0/lvds_transceiver_mw/serdes_10_to_1_ser8_i/oserdes_m}]
 
-# create_pblock MPS_RTL_GRP; add_cells_to_pblock [get_pblocks MPS_RTL_GRP] [get_cells [list U_Core/GEN_EN_MPS.U_AppMps/U_Salt/APP_SLOT.U_SaltUltraScale]]
-# resize_pblock [get_pblocks MPS_RTL_GRP] -add {CLOCKREGION_X2Y5:CLOCKREGION_X2Y5}
+create_pblock MPS_RTL_GRP; add_cells_to_pblock [get_pblocks MPS_RTL_GRP] [get_cells [list U_Core/GEN_EN_MPS.U_AppMps/U_Salt/APP_SLOT.U_SaltUltraScale]]
+resize_pblock [get_pblocks MPS_RTL_GRP] -add {CLOCKREGION_X2Y6:CLOCKREGION_X2Y6}
 
 ##########################
 ## Misc. Configurations ##

--- a/AppTop/rtl/xcku11p/AppTop.vhd
+++ b/AppTop/rtl/xcku11p/AppTop.vhd
@@ -39,6 +39,7 @@ entity AppTop is
       SIMULATION_G           : boolean                   := false;
       DAQMUX_DECIMATOR_EN_G  : boolean                   := true;
       MR_LCLS_APP_G          : boolean                   := false;
+      WAVEFORM_NUM_LANES_G   : positive                  := 4;
       WAVEFORM_TDATA_BYTES_G : positive                  := 4;
       TIMING_BUS_DOMAIN_G    : string                    := "REC_CLK";
       -- JESD Generics
@@ -82,10 +83,10 @@ entity AppTop is
       -- Waveform interface (waveformClk domain)
       waveformClk          : in    sl;
       waveformRst          : in    sl;
-      obAppWaveformMasters : out   WaveformMasterArrayType;
-      obAppWaveformSlaves  : in    WaveformSlaveArrayType;
-      ibAppWaveformMasters : in    WaveformMasterArrayType;
-      ibAppWaveformSlaves  : out   WaveformSlaveArrayType;
+      obAppWaveformMasters : out   WaveformMasterArrayType := (others=>(others=>AXI_STREAM_MASTER_INIT_C));
+      obAppWaveformSlaves  : in    WaveformSlaveArrayType  := (others=>(others=>WAVEFORM_SLAVE_REC_FORCE_C));
+      ibAppWaveformMasters : in    WaveformMasterArrayType := (others=>(others=>AXI_STREAM_MASTER_INIT_C));
+      ibAppWaveformSlaves  : out   WaveformSlaveArrayType  := (others=>(others=>WAVEFORM_SLAVE_REC_FORCE_C));
       -- Backplane Messaging Interface  (axilClk domain)
       obBpMsgClientMaster  : out   AxiStreamMasterType;
       obBpMsgClientSlave   : in    AxiStreamSlaveType;
@@ -201,6 +202,14 @@ architecture mapping of AppTop is
    signal dacSigStatus : DacSigStatusArray(1 downto 0);
    signal dacSigValids : Slv10Array(1 downto 0);
    signal dacSigValues : sampleDataVectorArray(1 downto 0, 9 downto 0);
+   
+   type WaveMasterArray is array (natural range <>) of AxiStreamMasterArray(WAVEFORM_NUM_LANES_G-1 downto 0);   
+   type WaveSlaveArray is array (natural range <>) of AxiStreamSlaveArray(WAVEFORM_NUM_LANES_G-1 downto 0);   
+   type WaveCtrlArray is array (natural range <>) of AxiStreamCtrlArray(WAVEFORM_NUM_LANES_G-1 downto 0);   
+   
+   signal waveAxisMasterArr : WaveMasterArray(1 downto 0);
+   signal waveAxisSlaveArr  : WaveSlaveArray(1 downto 0);
+   signal waveAxisCtrlArr   : WaveCtrlArray(1 downto 0);
 
 begin
 
@@ -303,7 +312,7 @@ begin
             WAVEFORM_TDATA_BYTES_G => WAVEFORM_TDATA_BYTES_G,
             BAY_INDEX_G            => ite((i = 0), '0', '1'),
             N_DATA_IN_G            => 24,
-            N_DATA_OUT_G           => 4)
+            N_DATA_OUT_G           => WAVEFORM_NUM_LANES_G)
          port map (
             -- Clocks and Resets
             axiClk              => axilClk,
@@ -362,15 +371,20 @@ begin
             -- Output AXI Streaming Interface (Has to be synced with waveform clk)
             wfClk_i             => waveformClk,
             wfRst_i             => waveformRst,
-            rxAxisMasterArr_o   => obAppWaveformMasters(i),
-            rxAxisSlaveArr_i(0) => obAppWaveformSlaves(i)(0).slave,
-            rxAxisSlaveArr_i(1) => obAppWaveformSlaves(i)(1).slave,
-            rxAxisSlaveArr_i(2) => obAppWaveformSlaves(i)(2).slave,
-            rxAxisSlaveArr_i(3) => obAppWaveformSlaves(i)(3).slave,
-            rxAxisCtrlArr_i(0)  => obAppWaveformSlaves(i)(0).ctrl,
-            rxAxisCtrlArr_i(1)  => obAppWaveformSlaves(i)(1).ctrl,
-            rxAxisCtrlArr_i(2)  => obAppWaveformSlaves(i)(2).ctrl,
-            rxAxisCtrlArr_i(3)  => obAppWaveformSlaves(i)(3).ctrl);
+            rxAxisMasterArr_o   => waveAxisMasterArr(i),
+            rxAxisSlaveArr_i    => waveAxisSlaveArr(i),
+            rxAxisCtrlArr_i     => waveAxisCtrlArr(i));
+            
+         
+      U_WaveLane : for j in WAVEFORM_NUM_LANES_G-1 downto 0 generate
+         
+         obAppWaveformMasters(i)(j) <= waveAxisMasterArr(i)(j);
+         
+         waveAxisSlaveArr(i)(j) <= obAppWaveformSlaves(i)(j).slave;
+         waveAxisCtrlArr(i)(j)  <= obAppWaveformSlaves(i)(j).ctrl;
+      
+      end generate U_WaveLane;
+
 
       dataValids(i) <= debugValids(i) & dacValids(i) & adcValids(i);
       linkReady(i)  <= x"F" & dacValids(i) & adcValids(i);

--- a/BsaCore/rtl/BsaWaveformEngine.vhd
+++ b/BsaCore/rtl/BsaWaveformEngine.vhd
@@ -29,6 +29,7 @@ entity BsaWaveformEngine is
 
    generic (
       TPD_G                  : time                   := 1 ns;
+      WAVEFORM_NUM_LANES_G   : positive range 1 to 4  := 4;
       WAVEFORM_TDATA_BYTES_G : positive range 4 to 16 := 4;
       AXIL_BASE_ADDR_G       : slv(31 downto 0)       := (others => '0');
       AXI_CONFIG_G           : AxiConfigType          := axiConfig(33, 16, 1, 8));
@@ -37,7 +38,7 @@ entity BsaWaveformEngine is
       waveformClk : in sl;
       waveformRst : in sl;
       ibWaveformMasters : in  WaveformMasterType;
-      ibWaveformSlaves  : out WaveformSlaveType;
+      ibWaveformSlaves  : out WaveformSlaveType := (others=>WAVEFORM_SLAVE_REC_FORCE_C);
       -- AXI-Lite configuration interface
       axilClk           : in  sl;
       axilRst           : in  sl;
@@ -72,7 +73,8 @@ architecture rtl of BsaWaveformEngine is
    constant WAVEFORM_AXIS_CONFIG_C : AxiStreamConfigType :=
       ssiAxiStreamConfig(WAVEFORM_TDATA_BYTES_G, TKEEP_FIXED_C, TUSER_FIRST_LAST_C, 0, 3);  -- No tdest bits, 3 tUser bits
 
-   constant STREAMS_C : integer := WaveformMasterType'length;
+   -- constant STREAMS_C : positive := WaveformMasterType'length;
+   constant STREAMS_C : positive := WAVEFORM_NUM_LANES_G;
 
    constant TDEST_ROUTES_C : Slv8Array(STREAMS_C-1 downto 0) := (others => "--------");
 
@@ -82,7 +84,7 @@ architecture rtl of BsaWaveformEngine is
    constant WRITE_AXIS_CONFIG_C : AxiStreamConfigType := (
       TSTRB_EN_C    => false,
       TDATA_BYTES_C => AXI_CONFIG_G.DATA_BYTES_C,
-      TDEST_BITS_C  => log2(STREAMS_C),
+      TDEST_BITS_C  => bitSize(STREAMS_C-1),
       TID_BITS_C    => 0,
       TKEEP_MODE_C  => TKEEP_FIXED_C,
       TUSER_BITS_C  => 3,
@@ -118,7 +120,7 @@ architecture rtl of BsaWaveformEngine is
    constant READ_AXIS_CONFIG_C : AxiStreamConfigType := (
       TSTRB_EN_C    => false,
       TDATA_BYTES_C => AXI_CONFIG_G.DATA_BYTES_C,
-      TDEST_BITS_C  => log2(STREAMS_C),
+      TDEST_BITS_C  => bitSize(STREAMS_C-1),
       TID_BITS_C    => 0,
       TKEEP_MODE_C  => TKEEP_FIXED_C,
       TUSER_BITS_C  => 2,

--- a/BsaCore/rtl/BsaWaveformEngine.vhd
+++ b/BsaCore/rtl/BsaWaveformEngine.vhd
@@ -330,6 +330,8 @@ begin
          FIFO_ADDR_WIDTH_G   => 4,
          FIFO_FIXED_THRESH_G => true,
          FIFO_PAUSE_THRESH_G => 1,
+         INT_WIDTH_SELECT_G  => "CUSTOM",
+         INT_DATA_WIDTH_G    => 4, -- Limitting the bandwidth to 5 Gb/s  = 32-bit (4B) x 156.25 MHz    
          SLAVE_AXI_CONFIG_G  => READ_AXIS_CONFIG_C,
          MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
       port map (

--- a/BsaCore/rtl/BsaWaveformEngine.vhd
+++ b/BsaCore/rtl/BsaWaveformEngine.vhd
@@ -330,8 +330,6 @@ begin
          FIFO_ADDR_WIDTH_G   => 4,
          FIFO_FIXED_THRESH_G => true,
          FIFO_PAUSE_THRESH_G => 1,
-         INT_WIDTH_SELECT_G  => "CUSTOM",
-         INT_DATA_WIDTH_G    => 4, -- Limitting the bandwidth to 5 Gb/s  = 32-bit (4B) x 156.25 MHz    
          SLAVE_AXI_CONFIG_G  => READ_AXIS_CONFIG_C,
          MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
       port map (

--- a/BsaCore/rtl/BsaWaveformEngine.vhd
+++ b/BsaCore/rtl/BsaWaveformEngine.vhd
@@ -331,7 +331,7 @@ begin
          FIFO_FIXED_THRESH_G => true,
          FIFO_PAUSE_THRESH_G => 1,
          SLAVE_AXI_CONFIG_G  => READ_AXIS_CONFIG_C,
-         MASTER_AXI_CONFIG_G => ETH_AXIS_CONFIG_C)
+         MASTER_AXI_CONFIG_G => AXIS_8BYTE_CONFIG_C)
       port map (
          sAxisClk    => axiClk,
          sAxisRst    => axiRst,

--- a/BsaCore/rtl/SsiAxiMaster.vhd
+++ b/BsaCore/rtl/SsiAxiMaster.vhd
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------------------
+-- Title      : Memory Access Protocol (MAP) Protocol: https://confluence.slac.stanford.edu/x/dBmVD
+-------------------------------------------------------------------------------
 -- File       : SsiAxiMaster.vhd
--- Created    : 2014-04-09
--- Last update: 2016-02-09
+-- Company    : SLAC National Accelerator Laboratory
 -------------------------------------------------------------------------------
 -- Description:
 -- Block for Register protocol.

--- a/DaqMuxV2/rtl/DaqRegItf.vhd
+++ b/DaqMuxV2/rtl/DaqRegItf.vhd
@@ -31,7 +31,7 @@ entity DaqRegItf is
       TPD_G            : time     := 1 ns;
       AXI_ADDR_WIDTH_G : positive := 10;
       N_DATA_IN_G      : positive := 16;
-      N_DATA_OUT_G     : positive := 8
+      N_DATA_OUT_G     : positive := 4
       );
    port (
       -- Axi-Lite Clk
@@ -243,6 +243,11 @@ begin
                v.axilReadSlave.rdata(N_DATA_IN_G-1 downto 0) := s_sampleValid;
             when 16#0c# =>              -- ADDR (0x30)
                v.axilReadSlave.rdata(N_DATA_IN_G-1 downto 0) := s_linkReady;
+            when 16#0d# =>              -- ADDR (0x34)
+               v.axilReadSlave.rdata(7 downto 0)   := toSlv(AXI_ADDR_WIDTH_G,8);
+               v.axilReadSlave.rdata(15 downto 8)  := toSlv(N_DATA_IN_G,8);
+               v.axilReadSlave.rdata(23 downto 16) := toSlv(N_DATA_OUT_G,8);
+               v.axilReadSlave.rdata(31 downto 24) := x"00";               
             when 16#10# to 16#1F# =>    -- ADDR (0x40)
                for I in (N_DATA_OUT_G-1) downto 0 loop
                   if (axilReadMaster.araddr(5 downto 2) = I) then

--- a/python/AmcCarrierCore/AmcCarrierBsa.py
+++ b/python/AmcCarrierCore/AmcCarrierBsa.py
@@ -25,6 +25,7 @@ class AmcCarrierBsa(pr.Device):
             name        = "AmcCarrierBsa", 
             description = "AmcCarrier BSA Module", 
             enableBsa   = True,
+            numWaveformBuffers  = 4,
             **kwargs):
         super().__init__(name=name, description=description, **kwargs)
         
@@ -39,6 +40,7 @@ class AmcCarrierBsa(pr.Device):
 
         for i in range(2):
             self.add(bsa.BsaWaveformEngine(
-                name   = f'BsaWaveformEngine[{i}]',
-                offset =  0x00010000 + i * 0x00010000,
+                name       = f'BsaWaveformEngine[{i}]',
+                offset     =  0x00010000 + i * 0x00010000,
+                numBuffers = numWaveformBuffers,
             ))

--- a/python/AmcCarrierCore/AmcCarrierCore.py
+++ b/python/AmcCarrierCore/AmcCarrierCore.py
@@ -76,12 +76,12 @@ class AmcCarrierCore(pr.Device):
                 -----------------------------------------------------------------\n"\
             ))
                             
-        self.add(ti.AxiCdcm6208(     
-            offset       =  0x05000000, 
-            enabled      =  False,
-            hidden       =  True,
-            expand       =  False,            
-        ))
+        # self.add(ti.AxiCdcm6208(     
+            # offset       =  0x05000000, 
+            # enabled      =  False,
+            # hidden       =  True,
+            # expand       =  False,            
+        # ))
 
         self.add(amcc.AmcCarrierBsi(   
             offset       =  0x07000000, 

--- a/python/AmcCarrierCore/AmcCarrierCore.py
+++ b/python/AmcCarrierCore/AmcCarrierCore.py
@@ -23,7 +23,8 @@ class AmcCarrierCore(pr.Device):
             rssiInterlaved      = False,            
             enableBsa           = True,
             enableMps           = True,
-            expand	            = False,
+            enableTpgMini       = True,
+            expand	        = False,
             **kwargs):
         super().__init__(name=name, description=description, expand=expand, **kwargs)  
 
@@ -89,8 +90,9 @@ class AmcCarrierCore(pr.Device):
         ))
 
         self.add(amcc.AmcCarrierTiming(
-            offset       =  0x08000000, 
-            expand       =  False,
+            offset        =  0x08000000, 
+            expand        =  False,
+            enableTpgMini = enableTpgMini,
         ))
 
         self.add(amcc.AmcCarrierBsa(   

--- a/python/AmcCarrierCore/AmcCarrierCore.py
+++ b/python/AmcCarrierCore/AmcCarrierCore.py
@@ -23,8 +23,9 @@ class AmcCarrierCore(pr.Device):
             rssiInterlaved      = False,            
             enableBsa           = True,
             enableMps           = True,
+            numWaveformBuffers  = 4,
             enableTpgMini       = True,
-            expand	        = False,
+            expand	            = False,
             **kwargs):
         super().__init__(name=name, description=description, expand=expand, **kwargs)  
 
@@ -96,9 +97,10 @@ class AmcCarrierCore(pr.Device):
         ))
 
         self.add(amcc.AmcCarrierBsa(   
-            offset       =  0x09000000, 
-            enableBsa    =  enableBsa,
-            expand       =  False,
+            offset             =  0x09000000, 
+            enableBsa          =  enableBsa,
+            numWaveformBuffers =  numWaveformBuffers,
+            expand             =  False,
         ))
                             
         self.add(udp.UdpEngineClient(

--- a/python/AmcCarrierCore/AmcCarrierCore.py
+++ b/python/AmcCarrierCore/AmcCarrierCore.py
@@ -78,7 +78,9 @@ class AmcCarrierCore(pr.Device):
                             
         self.add(ti.AxiCdcm6208(     
             offset       =  0x05000000, 
-            expand       =  False,
+            enabled      =  False,
+            hidden       =  True,
+            expand       =  False,            
         ))
 
         self.add(amcc.AmcCarrierBsi(   

--- a/python/AmcCarrierCore/AmcCarrierTiming.py
+++ b/python/AmcCarrierCore/AmcCarrierTiming.py
@@ -22,8 +22,9 @@ import LclsTimingCore as timingCore
 
 class AmcCarrierTiming(pr.Device):
     def __init__(   self, 
-            name        = "AmcCarrierTiming", 
-            description = "AMC Carrier Timing Receiver Module", 
+            name          = "AmcCarrierTiming", 
+            description   = "AMC Carrier Timing Receiver Module", 
+            enableTpgMini = True,
             **kwargs):
         super().__init__(name=name, description=description, **kwargs)
 
@@ -35,9 +36,10 @@ class AmcCarrierTiming(pr.Device):
             offset = 0x00000000,
         ))
 
-        self.add(timingCore.TPGMiniCore(
-            offset = 0x00030000,
-        ))
+        if (enableTpgMini):
+            self.add(timingCore.TPGMiniCore(
+                offset = 0x00030000,
+            ))
         
         self.add(timingCore.EvrV2CoreTriggers(
             offset = 0x00040000,

--- a/python/AppHardware/AmcGenericAdcDac/_AmcGenericAdcDacCtrl.py
+++ b/python/AppHardware/AmcGenericAdcDac/_AmcGenericAdcDacCtrl.py
@@ -30,11 +30,9 @@ class AmcGenericAdcDacCtrl(pr.Device):
             name         = "AdcValidCnt",
             description  = "ADC Valid Transition Counter[3:0]",
             offset       = 0x00,
-            bitSize      = 32,
-            bitOffset    = 0,            
+            bitSize      = 32,            
             number       = 4,
             stride       = 4,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval = 1,
         )
@@ -44,8 +42,6 @@ class AmcGenericAdcDacCtrl(pr.Device):
             description  = "ADC Valid[3:0]",
             offset       = 0x0FC,
             bitSize      = 4,
-            bitOffset    = 0,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval = 1,
         ))          
@@ -55,8 +51,6 @@ class AmcGenericAdcDacCtrl(pr.Device):
             description  = "ADC Data[3:0]",
             offset       =  0x100,
             bitSize      =  16,
-            bitOffset    =  0,
-            base         = pr.UInt,
             mode         = "RO",
             number       =  4,
             stride       =  4,
@@ -68,8 +62,6 @@ class AmcGenericAdcDacCtrl(pr.Device):
             description  = "DAC Data[1:0]",
             offset       =  0x110,
             bitSize      =  16,
-            bitOffset    =  0,
-            base         = pr.UInt,
             mode         = "RO",
             number       =  2,
             stride       =  4,
@@ -81,8 +73,6 @@ class AmcGenericAdcDacCtrl(pr.Device):
             description  = "VCO's DAC Value",
             offset       = 0x1F8,
             bitSize      = 16,
-            bitOffset    = 0,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval = 1,
         ))          
@@ -92,10 +82,9 @@ class AmcGenericAdcDacCtrl(pr.Device):
             description  = "AMC Clock frequency",
             offset       = 0x1FC,
             bitSize      = 32,
-            bitOffset    = 0,
-            base         = pr.UInt,
             mode         = "RO",
             units        = "Hz",
+            disp         = '{:d}',
             pollInterval = 1,
         ))          
                 
@@ -105,7 +94,6 @@ class AmcGenericAdcDacCtrl(pr.Device):
             offset       = 0x200,
             bitSize      = 2,
             bitOffset    = 0,
-            base         = pr.UInt,
             mode         = "RW",
         ))   
                 
@@ -114,8 +102,6 @@ class AmcGenericAdcDacCtrl(pr.Device):
             description  = "LMK Reset",
             offset       = 0x204,
             bitSize      = 1,
-            bitOffset    = 0,
-            base         = pr.UInt,
             mode         = "RW",
         ))   
                 
@@ -124,8 +110,6 @@ class AmcGenericAdcDacCtrl(pr.Device):
             description  = "LMK SYNC",
             offset       = 0x208,
             bitSize      = 1,
-            bitOffset    = 0,
-            base         = pr.UInt,
             mode         = "RW",
         ))           
         
@@ -134,8 +118,6 @@ class AmcGenericAdcDacCtrl(pr.Device):
             description  = "LMK Status",
             offset       = 0x20C,
             bitSize      = 2,
-            bitOffset    = 0,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval = 1,
         ))   
@@ -145,8 +127,6 @@ class AmcGenericAdcDacCtrl(pr.Device):
             description  = "LMK Clock MUX Select",
             offset       = 0x214,
             bitSize      = 1,
-            bitOffset    = 0,
-            base         = pr.UInt,
             mode         = "RW",
         )) 
 
@@ -155,8 +135,6 @@ class AmcGenericAdcDacCtrl(pr.Device):
             description  = "VCO DAC SCK Rate Configuration",
             offset       = 0x220,
             bitSize      = 16,
-            bitOffset    = 0,
-            base         = pr.UInt,
             mode         = "RW",
         ))         
         
@@ -165,8 +143,6 @@ class AmcGenericAdcDacCtrl(pr.Device):
             description  = "VCO DAC Enable",
             offset       = 0x224,
             bitSize      = 1,
-            bitOffset    = 0,
-            base         = pr.UInt,
             mode         = "RW",
         ))   
         
@@ -175,17 +151,16 @@ class AmcGenericAdcDacCtrl(pr.Device):
             description  = "Enable Status counter roll over",
             offset       = 0x3F8,
             bitSize      = 4,
-            bitOffset    = 0,
-            base         = pr.UInt,
             mode         = "RW",
         ))           
-                                
-        self.add(pr.RemoteVariable( 
-            name         = "CntRst",
-            description  = "Status counter reset",
+
+        self.add(pr.RemoteCommand(   
+            name         = 'CntRst',
+            description  = 'Status counter reset',
             offset       = 0x3FC,
             bitSize      = 1,
-            bitOffset    = 0,
-            base         = pr.UInt,
-            mode         = "WO",
-        ))  
+            function     = pr.BaseCommand.touchOne
+        ))        
+        
+    def countReset(self):
+        self.CntRst()

--- a/python/AppTop/AppTop.py
+++ b/python/AppTop/AppTop.py
@@ -38,6 +38,7 @@ class AppTop(pr.Device):
             numSigGen      = [0,0],
             sizeSigGen     = [0,0],
             modeSigGen     = [False,False],
+            numWaveformBuffers  = 4,
             **kwargs):
         super().__init__(name=name, description=description, **kwargs)
         
@@ -59,9 +60,10 @@ class AppTop(pr.Device):
 
         for i in range(2):
             self.add(daqMuxV2.DaqMuxV2(
-                name         = f'DaqMuxV2[{i}]',
-                offset       =  0x20000000 + (i * 0x10000000),
-                expand       =  False,
+                name       = f'DaqMuxV2[{i}]',
+                offset     =  0x20000000 + (i * 0x10000000),
+                numBuffers =  numWaveformBuffers,
+                expand     =  False,
             ))
 
         for i in range(2):

--- a/python/AppTop/AppTop.py
+++ b/python/AppTop/AppTop.py
@@ -94,6 +94,7 @@ class AppTop(pr.Device):
             jesdRxDevices = self.find(typ=jesd.JesdRx)
             jesdTxDevices = self.find(typ=jesd.JesdTx)
             dacDevices    = self.find(typ=ti.Dac38J84)
+            lmkDevices    = self.find(typ=ti.Lmk04828)
             appCore       = self.find(typ=appCommon.AppCore)
             sigGenDevices = self.find(typ=dacSigGen.DacSigGen)
             
@@ -122,6 +123,18 @@ class AppTop(pr.Device):
                 core.Init()
             time.sleep(1.0)
             
+            # Special DAC Init procedure
+            for dac in dacDevices: 
+                dac.EnableTx.set(0x0)
+                dac.InitJesd.set(0x1)
+                dac.JesdRstN.set(0x0)
+                dac.JesdRstN.set(0x1)
+                dac.InitJesd.set(0x0)
+                dac.EnableTx.set(0x1)
+            if len(dacDevices) > 0:
+                for lmk in lmkDevices:
+                    lmk.PwrUpSysRef()
+         
             # Clear all error counters
             for rx in jesdRxDevices: 
                 rx.CmdClearErrors()  

--- a/python/AppTop/AppTop.py
+++ b/python/AppTop/AppTop.py
@@ -91,34 +91,51 @@ class AppTop(pr.Device):
             # Get devices
             jesdRxDevices = self.find(typ=jesd.JesdRx)
             jesdTxDevices = self.find(typ=jesd.JesdTx)
+            dacDevices    = self.find(typ=ti.Dac38J84)
             appCore       = self.find(typ=appCommon.AppCore)
             sigGenDevices = self.find(typ=dacSigGen.DacSigGen)
             
-            # Power down AppCore (power down SysRef)
+            # Assert GTs Reset
+            for rx in jesdRxDevices: 
+                rx.ResetGTs.set(1)
+            for tx in jesdTxDevices: 
+                rx.ResetGTs.set(1)      
+            self.checkBlocks(recurse=True)
+            time.sleep(0.5)
+            
+            # Execute the AppCore.Disable
             for core in appCore:
                 core.Disable()
-            # GTs Reset
+
+            # Deassert GTs Reset
             for rx in jesdRxDevices: 
-                rx.CmdResetGTs()
+                rx.ResetGTs.set(0)
             for tx in jesdTxDevices: 
-                tx.CmdResetGTs()
+                tx.ResetGTs.set(0)
             self.checkBlocks(recurse=True)
-            time.sleep(1.0)
+            time.sleep(0.5)
+            
             # Init the AppCore
             for core in appCore:
                 core.Init()
-            # Wait for the system settle
-            time.sleep(0.5)            
+            time.sleep(1.0)
+            
             # Clear all error counters
             for rx in jesdRxDevices: 
                 rx.CmdClearErrors()  
             for tx in jesdTxDevices: 
                 tx.CmdClearErrors()
+            for dac in dacDevices: 
+                enable = dac.enable.get()
+                dac.enable.set(True)
+                dac.ClearAlarms()
+                dac.enable.set(enable)                
+                
             # Load the DAC signal generator
             for sigGen in sigGenDevices: 
                 if ( sigGen.CsvFilePath.get() != "" ):
                     sigGen.LoadCsvFile("")
-                    
+                                   
     def writeBlocks(self, **kwargs):
         super().writeBlocks(**kwargs)
                         

--- a/python/AppTop/TopLevel.py
+++ b/python/AppTop/TopLevel.py
@@ -47,6 +47,7 @@ class TopLevel(pr.Device):
             # General Parameters
             enableBsa       = False,
             enableMps       = False,
+            numWaveformBuffers  = 4,
             expand          = True,
             enableTpgMini   = True,
             **kwargs):
@@ -142,6 +143,7 @@ class TopLevel(pr.Device):
             rssiNotInterlaved = rssiNotInterlaved,
             enableBsa         = enableBsa,
             enableMps         = enableMps,
+            numWaveformBuffers= numWaveformBuffers,
             enableTpgMini     = enableTpgMini,
         ))
         self.add(appTop.AppTop(
@@ -153,6 +155,7 @@ class TopLevel(pr.Device):
             numSigGen    = numSigGen,
             sizeSigGen   = sizeSigGen,
             modeSigGen   = modeSigGen,
+            numWaveformBuffers = numWaveformBuffers,
             expand       = True,
         ))
 

--- a/python/AppTop/TopLevel.py
+++ b/python/AppTop/TopLevel.py
@@ -55,6 +55,7 @@ class TopLevel(pr.Device):
 
         self._numRxLanes = numRxLanes
         self._numTxLanes = numTxLanes
+        self._numWaveformBuffers = numWaveformBuffers
         
         rssiInterlaved    = False
         rssiNotInterlaved = False
@@ -172,10 +173,10 @@ class TopLevel(pr.Device):
         self._root.checkBlocks(recurse=True)
 
         # Calculate the BsaWaveformEngine buffer sizes
-        size    = [[0,0,0,0],[0,0,0,0]]
+        size    = [[0]*self._numWaveformBuffers,[0]*self._numWaveformBuffers]
         for i in range(2):
             if ((self._numRxLanes[i] > 0) or (self._numTxLanes[i] > 0)):
-                for j in range(4):
+                for j in range(self._numWaveformBuffers):
                     waveBuff = self.AmcCarrierCore.AmcCarrierBsa.BsaWaveformEngine[i].WaveformEngineBuffers
                     if ( (waveBuff.Enabled[j].get() > 0) and (waveBuff.EndAddr[j].get() > waveBuff.StartAddr[j].get()) ):
                         size[i][j] = waveBuff.EndAddr[j].get() - waveBuff.StartAddr[j].get()
@@ -184,7 +185,7 @@ class TopLevel(pr.Device):
         minSize = [size[0][0],size[1][0]]
         for i in range(2):
             if ((self._numRxLanes[i] > 0) or (self._numTxLanes[i] > 0)):
-                for j in range(4):
+                for j in range(self._numWaveformBuffers):
                     if ( size[i][j]<minSize[i] ):
                         minSize[i] = size[i][j]
 

--- a/python/AppTop/TopLevel.py
+++ b/python/AppTop/TopLevel.py
@@ -47,6 +47,7 @@ class TopLevel(pr.Device):
             # General Parameters
             enableBsa       = False,
             enableMps       = False,
+            enableTpgMini   = True,
             **kwargs):
         super().__init__(name=name, description=description, **kwargs)
 
@@ -140,6 +141,7 @@ class TopLevel(pr.Device):
             rssiNotInterlaved = rssiNotInterlaved,
             enableBsa         = enableBsa,
             enableMps         = enableMps,
+            enableTpgMini     = enableTpgMini,
         ))
         self.add(appTop.AppTop(
             memBase      = self.srp,

--- a/python/AppTop/TopLevel.py
+++ b/python/AppTop/TopLevel.py
@@ -47,9 +47,10 @@ class TopLevel(pr.Device):
             # General Parameters
             enableBsa       = False,
             enableMps       = False,
+            expand          = True,
             enableTpgMini   = True,
             **kwargs):
-        super().__init__(name=name, description=description, **kwargs)
+        super().__init__(name=name, description=description, expand=expand, **kwargs)
 
         self._numRxLanes = numRxLanes
         self._numTxLanes = numTxLanes
@@ -152,6 +153,7 @@ class TopLevel(pr.Device):
             numSigGen    = numSigGen,
             sizeSigGen   = sizeSigGen,
             modeSigGen   = modeSigGen,
+            expand       = True,
         ))
 
         # Define SW trigger command

--- a/python/BsaCore/BsaWaveformEngine.py
+++ b/python/BsaCore/BsaWaveformEngine.py
@@ -24,10 +24,13 @@ class BsaWaveformEngine(pr.Device):
     def __init__(   self, 
             name        = "BsaWaveformEngine", 
             description = "Configuration and status of the BSA dignosic buffers", 
+            numBuffers  = 4,
             **kwargs):
         super().__init__(name=name, description=description, **kwargs)
 
         self.add(axi.AxiStreamDmaRingWrite(
-            offset =  0x00000000,
-            name   = "WaveformEngineBuffers",
+            name       = "WaveformEngineBuffers",
+            offset     = 0x00000000,
+            numBuffers = numBuffers,
         ))
+        

--- a/python/DaqMuxV2/DaqMuxV2.py
+++ b/python/DaqMuxV2/DaqMuxV2.py
@@ -23,6 +23,7 @@ class DaqMuxV2(pr.Device):
     def __init__(   self,       
             name        = "DaqMuxV2",
             description = "Waveform Data Acquisition Module",
+            numBuffers  = 4,
             **kwargs):
         super().__init__(name=name, description=description, **kwargs)
 
@@ -36,7 +37,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x00,
             bitSize      =  1,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RW",
         ))
 
@@ -72,7 +72,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x00,
             bitSize      =  1,
             bitOffset    =  0x03,
-            base         = pr.UInt,
             mode         = "RW",
         ))
 
@@ -82,7 +81,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x00,
             bitSize      =  1,
             bitOffset    =  0x04,
-            base         = pr.UInt,
             mode         = "RW",
         ))
 
@@ -118,7 +116,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x00,
             bitSize      =  1,
             bitOffset    =  0x07,
-            base         = pr.UInt,
             mode         = "RW",
         ))
 
@@ -141,7 +138,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x04,
             bitSize      =  1,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
         ))
@@ -152,7 +148,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x04,
             bitSize      =  1,
             bitOffset    =  0x01,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
         ))
@@ -163,7 +158,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x04,
             bitSize      =  1,
             bitOffset    =  0x02,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
         ))
@@ -174,7 +168,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x04,
             bitSize      =  1,
             bitOffset    =  0x03,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
         ))
@@ -185,7 +178,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x04,
             bitSize      =  1,
             bitOffset    =  0x04,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
         ))
@@ -196,7 +188,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x04,
             bitSize      =  1,
             bitOffset    =  0x05,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
         ))
@@ -207,7 +198,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x08,
             bitSize      =  16,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RW",
         ))
 
@@ -217,7 +207,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x0C,
             bitSize      =  32,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RW",
         ))
 
@@ -227,7 +216,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x10,
             bitSize      =  32,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RO",
             number       =  2,
             stride       =  4,
@@ -240,9 +228,8 @@ class DaqMuxV2(pr.Device):
             offset       =  0x18,
             bitSize      =  32,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RO",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             pollInterval =  1,                            
         )
@@ -253,7 +240,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x28,
             bitSize      =  32,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
         ))
@@ -264,7 +250,6 @@ class DaqMuxV2(pr.Device):
             offset       =  0x2C,
             bitSize      =  32,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
         ))       
@@ -275,10 +260,33 @@ class DaqMuxV2(pr.Device):
             offset       =  0x30,
             bitSize      =  32,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RO",
             pollInterval =  1,                            
-        ))               
+        ))
+
+        self.add(pr.RemoteVariable(   
+            name         = "AXI_ADDR_WIDTH_G",
+            offset       =  0x34,
+            bitSize      =  8,
+            bitOffset    =  0,
+            mode         = 'RO',
+        ))  
+
+        self.add(pr.RemoteVariable(   
+            name         = "N_DATA_IN_G",
+            offset       =  0x34,
+            bitSize      =  8,
+            bitOffset    =  8,
+            mode         = 'RO',
+        ))     
+
+        self.add(pr.RemoteVariable(   
+            name         = "N_DATA_OUT_G",
+            offset       =  0x34,
+            bitSize      =  8,
+            bitOffset    =  16,
+            mode         = 'RO',
+        ))             
 
         self.addRemoteVariables(   
             name         = "InputMuxSel",
@@ -287,7 +295,7 @@ class DaqMuxV2(pr.Device):
             bitSize      =  5,
             bitOffset    =  0x00,
             mode         = "RW",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             enum         = {
                    0 : "Disabled",
@@ -331,9 +339,8 @@ class DaqMuxV2(pr.Device):
             offset       =  0x80,
             bitSize      =  1,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RO",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             pollInterval =  1,                            
         )
@@ -344,9 +351,8 @@ class DaqMuxV2(pr.Device):
             offset       =  0x80,
             bitSize      =  1,
             bitOffset    =  0x01,
-            base         = pr.UInt,
             mode         = "RO",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             pollInterval =  1,                            
         )
@@ -357,9 +363,8 @@ class DaqMuxV2(pr.Device):
             offset       =  0x80,
             bitSize      =  1,
             bitOffset    =  0x02,
-            base         = pr.UInt,
             mode         = "RO",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             pollInterval =  1,                            
         )
@@ -370,9 +375,8 @@ class DaqMuxV2(pr.Device):
             offset       =  0x80,
             bitSize      =  1,
             bitOffset    =  0x03,
-            base         = pr.UInt,
             mode         = "RO",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             pollInterval =  1,                            
         )
@@ -383,9 +387,8 @@ class DaqMuxV2(pr.Device):
             offset       =  0x80,
             bitSize      =  1,
             bitOffset    =  0x04,
-            base         = pr.UInt,
             mode         = "RO",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             pollInterval =  1,                            
         )
@@ -396,9 +399,8 @@ class DaqMuxV2(pr.Device):
             offset       =  0x80,
             bitSize      =  1,
             bitOffset    =  0x05,
-            base         = pr.UInt,
             mode         = "RO",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             pollInterval =  1,                            
         )
@@ -409,9 +411,8 @@ class DaqMuxV2(pr.Device):
             offset       =  0x80,
             bitSize      =  26,
             bitOffset    =  0x06,
-            base         = pr.UInt,
             mode         = "RO",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             pollInterval =  1,                            
         )
@@ -422,9 +423,8 @@ class DaqMuxV2(pr.Device):
             offset       =  0xC0,
             bitSize      =  5,
             bitOffset    =  0x00,
-            base         = pr.UInt,
             mode         = "RW",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
         )
 
@@ -435,7 +435,7 @@ class DaqMuxV2(pr.Device):
             bitSize      =  1,
             bitOffset    =  0x05,
             mode         = "RW",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             enum         = {
                 0 : "D32-bit",
@@ -450,7 +450,7 @@ class DaqMuxV2(pr.Device):
             bitSize      =  1,
             bitOffset    =  0x06,
             mode         = "RW",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             enum         = {
                 0 : "Unsigned",
@@ -465,7 +465,7 @@ class DaqMuxV2(pr.Device):
             bitSize      =  1,
             bitOffset    =  0x07,
             mode         = "RW",
-            number       =  4,
+            number       =  numBuffers,
             stride       =  4,
             enum         = {
                 0 : "Disabled",

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -5,7 +5,7 @@ proc MyVersionCheck { } {
 
    # Get the Vivado version
    set VersionNumber [version -short]
-   set supported "2017.4 2018.1 2018.2 2018.3"
+   set supported "2017.4 2018.1 2018.2 2018.3 2019.1"
    set retVar -1
    
    # Generate error message
@@ -36,7 +36,7 @@ set family [getFpgaFamily]
 # Check for submodule tagging
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
    if { [SubmoduleCheck {lcls-timing-core} {1.12.6} "mustBeExact" ] < 0 } {exit -1}
-   if { [SubmoduleCheck {ruckus}           {1.7.9}  "mustBeExact" ] < 0 } {exit -1}
+   if { [SubmoduleCheck {ruckus}           {1.8.0}  "mustBeExact" ] < 0 } {exit -1}
    if { [SubmoduleCheck {surf}             {1.9.11} "mustBeExact" ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -37,7 +37,7 @@ set family [getFpgaFamily]
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
    if { [SubmoduleCheck {lcls-timing-core} {1.12.6} "mustBeExact" ] < 0 } {exit -1}
    if { [SubmoduleCheck {ruckus}           {1.8.0}  "mustBeExact" ] < 0 } {exit -1}
-   if { [SubmoduleCheck {surf}             {1.9.11} "mustBeExact" ] < 0 } {exit -1}
+   if { [SubmoduleCheck {surf}             {1.10.0} "mustBeExact" ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"
    puts "OVERRIDE_SUBMODULE_LOCKS != 0"


### PR DESCRIPTION
### Description
- changed ETH_AXIS_CONFIG_C to AXIS_8BYTE_CONFIG_C
- Bug fix for the backplane server/client
- Adding APP_FWS_TYPE_C #207
- commenting out DDR I2c, AxiCdcm6208 and CAL I2C to help reduce FPGA resources
- adding VCCINT I2C to amc-carrirer-core FW 
- Updating MpsAppNodeKcu11p.xdc
- PyRogue fix for `numWaveformBuffers != 4` #217
- Adding special init() procedure for the DAC based on https://jira.slac.stanford.edu/browse/ESCRYODET-282 #218
- Adding WAVEFORM_NUM_LANES_G support #215
- AmcGenericAdcDac Python Updates #208
- Add generic to disable TPG Mini #216
- adding JesdSyncIn/Out to AppHardware/AmcCryoDemo/ and AppHardware/AmcCryo/ #211
- AppHardware/AmcMrLlrfUpConvert & AppHardware/AmcMrLlrfDownConvert Update #209
- adding JesdSyncIn/Out to AppHardware/AmcStriplineBpm/ #210