### PR TITLE
AmcGenericAdcDacCore-update

### DIFF
--- a/AppHardware/AmcGenericAdcDac/rtl/AmcGenericAdcDacCore.vhd
+++ b/AppHardware/AmcGenericAdcDac/rtl/AmcGenericAdcDacCore.vhd
@@ -178,6 +178,8 @@ architecture mapping of AmcGenericAdcDacCore is
    signal lemoDoutN   : slv(1 downto 0);
    signal lemoDinput  : slv(1 downto 0);
    signal bcmL        : sl;
+   signal smaTrigMon  : sl;
+   signal adcCalMon   : sl;
 
 begin
 
@@ -490,8 +492,8 @@ begin
          AXI_CLK_FREQ_G => AXI_CLK_FREQ_G)
       port map (
          -- Pass through Interfaces
-         smaTrig         => ite(TRIG_CLK_G, '0', smaTrig),
-         adcCal          => ite(CAL_CLK_G, '0', adcCal),
+         smaTrig         => smaTrigMon,
+         adcCal          => adcCalMon,
          lemoDin         => lemoDinput,
          lemoDout        => lemoDout,
          bcm             => bcm,
@@ -521,4 +523,7 @@ begin
          lmkRst          => lmkRst,
          lmkSync         => lmkSync);
 
+   smaTrigMon <= '0' when(TRIG_CLK_G) else smaTrig;
+   adcCalMon  <= '0' when(CAL_CLK_G) else adcCal;
+      
 end mapping;


### PR DESCRIPTION
### Description
Resolve the following error messages in Vivado when smaTrig or adcCal is not statically drive:
```
[Synth 8-1565] actual for formal port smatrig is neither a static name nor a globally static expression ["/firmware/submodules/amc-carrier-core/AppHardware/AmcGenericAdcDac/rtl/AmcGenericAdcDacCore.vhd":472] 
[Synth 8-1565] actual for formal port smatrig is neither a static name nor a globally static expression ["/firmware/submodules/amc-carrier-core/AppHardware/AmcGenericAdcDac/rtl/AmcGenericAdcDacCore.vhd":473]
```