### PR TITLE
adding multiple JesdTx sync support

### DIFF
--- a/AppHardware/AmcCryo/rtl/AmcCryoCore.vhd
+++ b/AppHardware/AmcCryo/rtl/AmcCryoCore.vhd
@@ -34,7 +34,7 @@ entity AmcCryoCore is
       -- JESD Interface
       jesdSysRef      : out   sl;
       jesdRxSync      : in    sl;
-      jesdTxSync      : out   sl;
+      jesdTxSync      : out   slv(9 downto 0);
       -- AXI-Lite Interface
       axilClk         : in    sl;
       axilRst         : in    sl;
@@ -332,7 +332,8 @@ begin
    jesdTxSyncVec(0) <= jesdTxSyncMask(0) or not(jesdTxSyncRaw(0));
    jesdTxSyncVec(1) <= jesdTxSyncMask(1) or jesdTxSyncRaw(1);
 
-   jesdTxSync <= jesdTxSyncVec(0) and jesdTxSyncVec(1);
+   jesdTxSync(4 downto 0) <= (others=>jesdTxSyncVec(0));
+   jesdTxSync(9 downto 5) <= (others=>jesdTxSyncVec(1));
 
    ----------------------------------------------------------------
    -- SPI interface ADC

--- a/AppHardware/AmcCryo/rtl/AmcCryoDualCore.vhd
+++ b/AppHardware/AmcCryo/rtl/AmcCryoDualCore.vhd
@@ -32,7 +32,7 @@ entity AmcCryoDualCore is
       -- JESD Interface
       jesdSysRef      : out   slv(1 downto 0);
       jesdRxSync      : in    slv(1 downto 0);
-      jesdTxSync      : out   slv(1 downto 0);
+      jesdTxSync      : out   Slv10Array(1 downto 0);
       -- AXI-Lite Interface
       axilClk         : in    sl;
       axilRst         : in    sl;

--- a/AppHardware/AmcCryoDemo/rtl/AmcCryoDemoCore.vhd
+++ b/AppHardware/AmcCryoDemo/rtl/AmcCryoDemoCore.vhd
@@ -37,7 +37,7 @@ entity AmcCryoDemoCore is
       -- JESD Interface
       jesdSysRef : out sl;
       jesdRxSync : in  sl;
-      jesdTxSync : out sl;
+      jesdTxSync : out slv(9 downto 0);
 
       -- AXI-Lite Interface
       axilClk         : in  sl;
@@ -130,6 +130,8 @@ architecture top_level_app of AmcCryoDemoCore is
    signal jesdRxSyncN : slv(3 downto 0);
    signal jesdTxSyncP : sl;
    signal jesdTxSyncN : sl;
+   
+   signal locJesdTxSync : sl;
 
    -------------------------------------------------------------------------------------------------
    -- SPI
@@ -263,7 +265,9 @@ begin
          jesdSyncP => jesdTxSyncP,
          jesdSyncN => jesdTxSyncN,
          -- JESD Low speed Interface
-         jesdSync  => jesdTxSync);
+         jesdSync  => locJesdTxSync);
+         
+   jesdTxSync <= (others=>locJesdTxSync);         
 
    ----------------------------------------------------------------
    -- SPI interface ADCs and LMK 

--- a/AppHardware/AmcCryoDemo/rtl/AmcCryoDemoDualCore.vhd
+++ b/AppHardware/AmcCryoDemo/rtl/AmcCryoDemoDualCore.vhd
@@ -35,7 +35,7 @@ entity AmcCryoDemoDualCore is
       -- JESD Interface
       jesdSysRef : out slv(1 downto 0);
       jesdRxSync : in  slv(1 downto 0);
-      jesdTxSync : out slv(1 downto 0);
+      jesdTxSync : out Slv10Array(1 downto 0);
 
       -- AXI-Lite Interface
       axilClk         : in    sl;

--- a/AppHardware/AmcGenericAdcDac/rtl/AmcGenericAdcDacCore.vhd
+++ b/AppHardware/AmcGenericAdcDac/rtl/AmcGenericAdcDacCore.vhd
@@ -43,7 +43,7 @@ entity AmcGenericAdcDacCore is
       jesdRst         : in    sl;
       jesdSysRef      : out   sl;
       jesdRxSync      : in    sl;
-      jesdTxSync      : out   sl;
+      jesdTxSync      : out   slv(9 downto 0);
       -- ADC/DAC Interface
       adcValids       : in    slv(3 downto 0);
       adcValues       : in    sampleDataArray(3 downto 0);
@@ -180,6 +180,8 @@ architecture mapping of AmcGenericAdcDacCore is
    signal bcmL        : sl;
    signal smaTrigMon  : sl;
    signal adcCalMon   : sl;
+   
+   signal locJesdTxSync : sl;   
 
 begin
 
@@ -349,7 +351,9 @@ begin
          jesdSyncP => jesdTxSyncP,
          jesdSyncN => jesdTxSyncN,
          -- JESD Low speed Interface
-         jesdSync  => jesdTxSync);
+         jesdSync  => locJesdTxSync);
+         
+   jesdTxSync <= (others=>locJesdTxSync);    
 
    GEN_RX_SYNC :
    for i in 1 downto 0 generate

--- a/AppHardware/AmcGenericAdcDac/rtl/AmcGenericAdcDacDualCore.vhd
+++ b/AppHardware/AmcGenericAdcDac/rtl/AmcGenericAdcDacDualCore.vhd
@@ -36,7 +36,7 @@ entity AmcGenericAdcDacDualCore is
       jesdRst         : in    slv(1 downto 0);
       jesdSysRef      : out   slv(1 downto 0);
       jesdRxSync      : in    slv(1 downto 0);
-      jesdTxSync      : out   slv(1 downto 0);
+      jesdTxSync      : out   Slv10Array(1 downto 0);
       -- ADC/DAC Interface (jesdClk domain)
       adcValids       : in    Slv7Array(1 downto 0);
       adcValues       : in    sampleDataVectorArray(1 downto 0, 6 downto 0);

--- a/AppHardware/AmcMicrowaveMux/rtl/AmcMicrowaveMuxCore.vhd
+++ b/AppHardware/AmcMicrowaveMux/rtl/AmcMicrowaveMuxCore.vhd
@@ -40,7 +40,7 @@ entity AmcMicrowaveMuxCore is
       jesdClk         : in    sl;
       jesdSysRef      : out   sl;
       jesdRxSync      : in    sl;
-      jesdTxSync      : out   sl;
+      jesdTxSync      : out   slv(9 downto 0);
       -- AXI-Lite Interface
       axilClk         : in    sl;
       axilRst         : in    sl;
@@ -537,7 +537,8 @@ begin
    jesdTxSyncVec(0) <= jesdTxSyncMask(0) or not(jesdTxSyncRaw(0));
    jesdTxSyncVec(1) <= jesdTxSyncMask(1) or jesdTxSyncRaw(1);
 
-   jesdTxSync <= jesdTxSyncVec(0) and jesdTxSyncVec(1);
+   jesdTxSync(4 downto 0) <= (others=>jesdTxSyncVec(0));
+   jesdTxSync(9 downto 5) <= (others=>jesdTxSyncVec(1));
 
    ----------------------------------------------------------------
    -- SPI interface ADC (ADC32R44)

--- a/AppHardware/AmcMicrowaveMux/rtl/AmcMicrowaveMuxDualCore.vhd
+++ b/AppHardware/AmcMicrowaveMux/rtl/AmcMicrowaveMuxDualCore.vhd
@@ -36,7 +36,7 @@ entity AmcMicrowaveMuxDualCore is
       jesdClk         : in    slv(1 downto 0);
       jesdSysRef      : out   slv(1 downto 0);
       jesdRxSync      : in    slv(1 downto 0);
-      jesdTxSync      : out   slv(1 downto 0);
+      jesdTxSync      : out   Slv10Array(1 downto 0);
       -- AXI-Lite Interface
       axilClk         : in    sl;
       axilRst         : in    sl;

--- a/AppHardware/AmcMrLlrfGen2UpConvert/core/AmcMrLlrfGen2UpConvert.vhd
+++ b/AppHardware/AmcMrLlrfGen2UpConvert/core/AmcMrLlrfGen2UpConvert.vhd
@@ -43,7 +43,7 @@ entity AmcMrLlrfGen2UpConvert is
       jesdRst2x       : in    sl;
       jesdSysRef      : out   sl;
       jesdRxSync      : in    sl;
-      jesdTxSync      : out   sl;
+      jesdTxSync      : out   slv(9 downto 0);
       -- Interlock and trigger
       timingTrig      : in    sl;
       fpgaInterlock   : in    sl;

--- a/AppHardware/AmcMrLlrfGen2UpConvert/core/AmcMrLlrfGen2UpConvertMapping.vhd
+++ b/AppHardware/AmcMrLlrfGen2UpConvert/core/AmcMrLlrfGen2UpConvertMapping.vhd
@@ -49,7 +49,7 @@ entity AmcMrLlrfGen2UpConvertMapping is
       fpgaInterlock : in    sl;
       i2cScl        : inout sl;
       i2cSda        : inout sl;
-      jesdTxSync    : out   sl;
+      jesdTxSync    : out   slv(9 downto 0);
       dacRst        : in    sl;
       dacCsL        : in    sl;
       dacSck        : in    sl;
@@ -83,6 +83,8 @@ end AmcMrLlrfGen2UpConvertMapping;
 architecture mapping of AmcMrLlrfGen2UpConvertMapping is
 
    signal timingTrigReg : sl;
+
+   signal locJesdTxSync : sl;   
 
 begin
 
@@ -216,6 +218,8 @@ begin
          jesdSyncP => spareP(9),
          jesdSyncN => spareN(9),
          -- JESD Low speed Interface
-         jesdSync  => jesdTxSync);
+         jesdSync  => locJesdTxSync);
+         
+   jesdTxSync <= (others=>locJesdTxSync);    
 
 end mapping;

--- a/AppTop/rtl/xcku040/AppTop.vhd
+++ b/AppTop/rtl/xcku040/AppTop.vhd
@@ -183,7 +183,7 @@ architecture mapping of AppTop is
    signal jesdRst2x  : slv(1 downto 0);
    signal jesdSysRef : slv(1 downto 0);
    signal jesdRxSync : slv(1 downto 0);
-   signal jesdTxSync : slv(1 downto 0);
+   signal jesdTxSync : Slv7Array(1 downto 0);
 
    signal adcValids : Slv7Array(1 downto 0);
    signal adcValues : sampleDataVectorArray(1 downto 0, 6 downto 0);

--- a/AppTop/rtl/xcku040/AppTopJesd.vhd
+++ b/AppTop/rtl/xcku040/AppTopJesd.vhd
@@ -52,7 +52,7 @@ entity AppTopJesd is
       jesdRst2x       : out sl;
       jesdSysRef      : in  sl;
       jesdRxSync      : out sl;
-      jesdTxSync      : in  sl;
+      jesdTxSync      : in  slv(6 downto 0);
       jesdUsrClk      : out sl;
       jesdUsrRst      : out sl;
       -- ADC Interface

--- a/AppTop/rtl/xcku040/AppTopJesd204b.vhd
+++ b/AppTop/rtl/xcku040/AppTopJesd204b.vhd
@@ -79,8 +79,8 @@ entity AppTopJesd204b is
       -- SYSREF for subclass 1 fixed latency
       sysRef_i        : in  sl;
       -- Synchronization output combined from all receivers to be connected to ADC/DAC chips
-      nSync_o         : out sl                    := '0';  -- Active HIGH
-      nSync_i         : in  sl);        -- Active HIGH
+      nSync_o         : out sl                    := '0';
+      nSync_i         : in  slv(6 downto 0));
 end AppTopJesd204b;
 
 architecture mapping of AppTopJesd204b is
@@ -266,7 +266,7 @@ begin
             devClk_i             => devClk_i,
             devRst_i             => devRst_i,
             sysRef_i             => s_sysRef,
-            nSync_i              => nSync_i,
+            nSync_i              => nSync_i(JESD_TX_LANE_G-1 downto 0),
             gtTxReady_i          => s_gtTxReady(JESD_TX_LANE_G-1 downto 0),
             gtTxReset_o          => s_gtTxUserReset(JESD_TX_LANE_G-1 downto 0),
             r_jesdGtTxArr        => r_jesdGtTxArr(JESD_TX_LANE_G-1 downto 0),

--- a/AppTop/rtl/xcku040_mpsln/AppTop.vhd
+++ b/AppTop/rtl/xcku040_mpsln/AppTop.vhd
@@ -192,7 +192,7 @@ architecture mapping of AppTop is
    signal jesdRst2x  : slv(1 downto 0);
    signal jesdSysRef : slv(1 downto 0);
    signal jesdRxSync : slv(1 downto 0);
-   signal jesdTxSync : slv(1 downto 0);
+   signal jesdTxSync : Slv5Array(1 downto 0);
 
    signal adcValids : Slv7Array(1 downto 0);
    signal adcValues : sampleDataVectorArray(1 downto 0, 6 downto 0);

--- a/AppTop/rtl/xcku040_mpsln/AppTopJesd.vhd
+++ b/AppTop/rtl/xcku040_mpsln/AppTopJesd.vhd
@@ -52,7 +52,7 @@ entity AppTopJesd is
       jesdRst2x       : out sl;
       jesdSysRef      : in  sl;
       jesdRxSync      : out sl;
-      jesdTxSync      : in  sl;
+      jesdTxSync      : in  slv(4 downto 0);
       jesdUsrClk      : out sl;
       jesdUsrRst      : out sl;
       -- ADC Interface

--- a/AppTop/rtl/xcku040_mpsln/AppTopJesd204b.vhd
+++ b/AppTop/rtl/xcku040_mpsln/AppTopJesd204b.vhd
@@ -79,8 +79,8 @@ entity AppTopJesd204b is
       -- SYSREF for subclass 1 fixed latency
       sysRef_i        : in  sl;
       -- Synchronization output combined from all receivers to be connected to ADC/DAC chips
-      nSync_o         : out sl                    := '0';  -- Active HIGH
-      nSync_i         : in  sl);        -- Active HIGH
+      nSync_o         : out sl                    := '0';
+      nSync_i         : in  slv(4 downto 0));
 end AppTopJesd204b;
 
 architecture mapping of AppTopJesd204b is
@@ -266,7 +266,7 @@ begin
             devClk_i             => devClk_i,
             devRst_i             => devRst_i,
             sysRef_i             => s_sysRef,
-            nSync_i              => nSync_i,
+            nSync_i              => nSync_i(JESD_TX_LANE_G-1 downto 0),
             gtTxReady_i          => s_gtTxReady(JESD_TX_LANE_G-1 downto 0),
             gtTxReset_o          => s_gtTxUserReset(JESD_TX_LANE_G-1 downto 0),
             r_jesdGtTxArr        => r_jesdGtTxArr(JESD_TX_LANE_G-1 downto 0),

--- a/AppTop/rtl/xcku060/AppTop.vhd
+++ b/AppTop/rtl/xcku060/AppTop.vhd
@@ -183,7 +183,7 @@ architecture mapping of AppTop is
    signal jesdRst2x  : slv(1 downto 0);
    signal jesdSysRef : slv(1 downto 0);
    signal jesdRxSync : slv(1 downto 0);
-   signal jesdTxSync : slv(1 downto 0);
+   signal jesdTxSync : Slv10Array(1 downto 0);
 
    signal adcValids : Slv10Array(1 downto 0);
    signal adcValues : sampleDataVectorArray(1 downto 0, 9 downto 0);

--- a/AppTop/rtl/xcku060/AppTopJesd.vhd
+++ b/AppTop/rtl/xcku060/AppTopJesd.vhd
@@ -53,7 +53,7 @@ entity AppTopJesd is
       jesdRst2x       : out sl;
       jesdSysRef      : in  sl;
       jesdRxSync      : out sl;
-      jesdTxSync      : in  sl;
+      jesdTxSync      : in  slv(9 downto 0);
       jesdUsrClk      : out sl;
       jesdUsrRst      : out sl;
       -- ADC Interface

--- a/AppTop/rtl/xcku060/AppTopJesd204b.vhd
+++ b/AppTop/rtl/xcku060/AppTopJesd204b.vhd
@@ -80,8 +80,8 @@ entity AppTopJesd204b is
       -- SYSREF for subclass 1 fixed latency
       sysRef_i        : in  sl;
       -- Synchronization output combined from all receivers to be connected to ADC/DAC chips
-      nSync_o         : out sl                    := '0';  -- Active HIGH
-      nSync_i         : in  sl);        -- Active HIGH
+      nSync_o         : out sl                    := '0';
+      nSync_i         : in  slv(9 downto 0));
 end AppTopJesd204b;
 
 architecture mapping of AppTopJesd204b is
@@ -350,7 +350,7 @@ begin
             devClk_i             => devClk_i,
             devRst_i             => devRst_i,
             sysRef_i             => s_sysRef,
-            nSync_i              => nSync_i,
+            nSync_i              => nSync_i(JESD_TX_LANE_G-1 downto 0),
             gtTxReady_i          => s_gtTxReady(JESD_TX_LANE_G-1 downto 0),
             gtTxReset_o          => s_gtTxUserReset(JESD_TX_LANE_G-1 downto 0),
             r_jesdGtTxArr        => r_jesdGtTxArr(JESD_TX_LANE_G-1 downto 0),

--- a/AppTop/rtl/xcku11p/AppTop.vhd
+++ b/AppTop/rtl/xcku11p/AppTop.vhd
@@ -184,7 +184,7 @@ architecture mapping of AppTop is
    signal jesdRst2x  : slv(1 downto 0);
    signal jesdSysRef : slv(1 downto 0);
    signal jesdRxSync : slv(1 downto 0);
-   signal jesdTxSync : slv(1 downto 0);
+   signal jesdTxSync : Slv10Array(1 downto 0);
 
    signal adcValids : Slv10Array(1 downto 0);
    signal adcValues : sampleDataVectorArray(1 downto 0, 9 downto 0);

--- a/AppTop/rtl/xcku11p/AppTopJesd.vhd
+++ b/AppTop/rtl/xcku11p/AppTopJesd.vhd
@@ -53,7 +53,7 @@ entity AppTopJesd is
       jesdRst2x       : out sl;
       jesdSysRef      : in  sl;
       jesdRxSync      : out sl;
-      jesdTxSync      : in  sl;
+      jesdTxSync      : in  slv(9 downto 0);
       jesdUsrClk      : out sl;
       jesdUsrRst      : out sl;
       -- ADC Interface

--- a/AppTop/rtl/xcku11p/AppTopJesd204b.vhd
+++ b/AppTop/rtl/xcku11p/AppTopJesd204b.vhd
@@ -79,8 +79,8 @@ entity AppTopJesd204b is
       -- SYSREF for subclass 1 fixed latency
       sysRef_i        : in  sl;
       -- Synchronization output combined from all receivers to be connected to ADC/DAC chips
-      nSync_o         : out sl                    := '0';  -- Active HIGH
-      nSync_i         : in  sl);        -- Active HIGH
+      nSync_o         : out sl                    := '0';
+      nSync_i         : in  slv(9 downto 0));
 end AppTopJesd204b;
 
 architecture mapping of AppTopJesd204b is
@@ -283,7 +283,7 @@ begin
             devClk_i             => devClk_i,
             devRst_i             => devRst_i,
             sysRef_i             => s_sysRef,
-            nSync_i              => nSync_i,
+            nSync_i              => nSync_i(JESD_TX_LANE_G-1 downto 0),
             gtTxReady_i          => s_gtTxReady(JESD_TX_LANE_G-1 downto 0),
             gtTxReset_o          => s_gtTxUserReset(JESD_TX_LANE_G-1 downto 0),
             r_jesdGtTxArr        => r_jesdGtTxArr(JESD_TX_LANE_G-1 downto 0),


### PR DESCRIPTION
### Description
- adding multiple JesdTx sync support
  - used for multiple DAC ICs with different SYNCs
- Addresses the issue in JIRA [ESCRYODET-401](https://jira.slac.stanford.edu/browse/ESCRYODET-401)
- This will break existing builds and require them to map each SYNC with respect to each TX JESD lane