### PR TITLE
Change the way the AppCore entity is instantiated

### DIFF
--- a/python/AppTop/TopLevel.py
+++ b/python/AppTop/TopLevel.py
@@ -50,6 +50,7 @@ class TopLevel(pr.Device):
             numWaveformBuffers  = 4,
             expand          = True,
             enableTpgMini   = True,
+            appCoreClass    = None,
             **kwargs):
         super().__init__(name=name, description=description, expand=expand, **kwargs)
 
@@ -158,6 +159,7 @@ class TopLevel(pr.Device):
             modeSigGen   = modeSigGen,
             numWaveformBuffers = numWaveformBuffers,
             expand       = True,
+            appCoreClass = appCoreClass
         ))
 
         # Define SW trigger command


### PR DESCRIPTION
This change removes the requirement of a 'common.AppCore' entity existing outside of the AmcCarrierCore namespaces. 

Instead of assuming the namespace exists in some external library, the class pointer for the core object will be passed through the TopLevel init().