### PR TITLE
New method for adding AppCore devices to AppTop device

### DIFF
--- a/python/AppTop/AppCore.py
+++ b/python/AppTop/AppCore.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+#-----------------------------------------------------------------------------
+# Title      : PyRogue Common Application Core Level
+#-----------------------------------------------------------------------------
+# File       : AppCore.py
+# Created    : 2019-10-08
+#-----------------------------------------------------------------------------
+# Description:
+# PyRogue Common Application Core template
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+import pyrogue as pr
+
+# A sub-class of this generic class should be added to 
+# the AppTop class from the application python
+
+#  self.TopLevel.AppTop.add(appCore(offset       =  0x00000000,     
+#                                   numRxLanes   =  numRxLanes,     
+#                                   numTxLanes   =  numTxLanes,     
+#                                   expand       =  True))
+
+class AppCore(pr.Device):
+    def __init__(self,
+            name        = "AppCore",
+            description = "AMC Carrier Cryo Demo Board Application",
+            offset      = 0x00000000,
+            numRxLanes  = [0,0],
+            numTxLanes  = [0,0],
+            **kwargs):
+        super().__init__(name=name, description=description, offset=offset, **kwargs)
+
+        self._numRxLanes = numRxLanes
+        self._numTxLanes = numTxLanes
+
+        self.add(py.LocalCommand(name='Init', description='Init', function=self.init))
+        self.add(py.LocalCommand(name='Disable', description='Disable', function=self.disable))
+
+    def init(self):
+        pass
+
+    def disable(self):
+        pass
+

--- a/python/AppTop/AppTop.py
+++ b/python/AppTop/AppTop.py
@@ -87,7 +87,7 @@ class AppTop(pr.Device):
             jesdTxDevices = self.find(typ=jesd.JesdTx)
             dacDevices    = self.find(typ=ti.Dac38J84)
             lmkDevices    = self.find(typ=ti.Lmk04828)
-            appCore       = self.find(typ=AppCore)
+            appCore       = self.find(typ=AppCore.AppCore)
             sigGenDevices = self.find(typ=dacSigGen.DacSigGen)
 
             # Assert GTs Reset

--- a/python/AppTop/AppTop.py
+++ b/python/AppTop/AppTop.py
@@ -37,7 +37,7 @@ class AppTop(pr.Device):
             numSigGen      = [0,0],
             sizeSigGen     = [0,0],
             modeSigGen     = [False,False],
-            numWaveformBuffers  = 4
+            numWaveformBuffers  = 4,
             **kwargs):
         super().__init__(name=name, description=description, **kwargs)
         

--- a/python/AppTop/AppTop.py
+++ b/python/AppTop/AppTop.py
@@ -20,6 +20,7 @@
 import time
 import pyrogue   as pr
 import AppTop    as appTop
+import AppCore
 import DacSigGen as dacSigGen
 import DaqMuxV2  as daqMuxV2
 
@@ -36,8 +37,7 @@ class AppTop(pr.Device):
             numSigGen      = [0,0],
             sizeSigGen     = [0,0],
             modeSigGen     = [False,False],
-            numWaveformBuffers  = 4,
-            appCoreClass   = None,
+            numWaveformBuffers  = 4
             **kwargs):
         super().__init__(name=name, description=description, **kwargs)
         
@@ -45,19 +45,10 @@ class AppTop(pr.Device):
         self._numTxLanes   = numTxLanes
         self._numSigGen    = numSigGen
         self._sizeSigGen   = sizeSigGen
-        self._appCoreClass = appCoreClass
         
         ##############################
         # Variables
         ##############################
-
-        if appCoreClass is not None:
-            self.add(appCoreClass(   
-                offset       =  0x00000000, 
-                numRxLanes   =  numRxLanes,
-                numTxLanes   =  numTxLanes,
-                expand       =  True,
-            ))
 
         for i in range(2):
             self.add(daqMuxV2.DaqMuxV2(
@@ -96,13 +87,9 @@ class AppTop(pr.Device):
             jesdTxDevices = self.find(typ=jesd.JesdTx)
             dacDevices    = self.find(typ=ti.Dac38J84)
             lmkDevices    = self.find(typ=ti.Lmk04828)
+            appCore       = self.find(typ=AppCore)
             sigGenDevices = self.find(typ=dacSigGen.DacSigGen)
 
-            if self._appCoreClass is not None:
-                appCore = self.find(typ=self._appCoreClass)
-            else:
-                appCore = []
-            
             # Assert GTs Reset
             for rx in jesdRxDevices: 
                 rx.ResetGTs.set(1)

--- a/python/AppTop/AppTop.py
+++ b/python/AppTop/AppTop.py
@@ -20,7 +20,6 @@
 import time
 import pyrogue   as pr
 import AppTop    as appTop
-import AppCore
 import DacSigGen as dacSigGen
 import DaqMuxV2  as daqMuxV2
 
@@ -87,7 +86,7 @@ class AppTop(pr.Device):
             jesdTxDevices = self.find(typ=jesd.JesdTx)
             dacDevices    = self.find(typ=ti.Dac38J84)
             lmkDevices    = self.find(typ=ti.Lmk04828)
-            appCore       = self.find(typ=AppCore.AppCore)
+            appCore       = self.find(typ=appTop.AppCore)
             sigGenDevices = self.find(typ=dacSigGen.DacSigGen)
 
             # Assert GTs Reset

--- a/python/AppTop/TopLevel.py
+++ b/python/AppTop/TopLevel.py
@@ -50,7 +50,6 @@ class TopLevel(pr.Device):
             numWaveformBuffers  = 4,
             expand          = True,
             enableTpgMini   = True,
-            appCoreClass    = None,
             **kwargs):
         super().__init__(name=name, description=description, expand=expand, **kwargs)
 
@@ -158,8 +157,7 @@ class TopLevel(pr.Device):
             sizeSigGen   = sizeSigGen,
             modeSigGen   = modeSigGen,
             numWaveformBuffers = numWaveformBuffers,
-            expand       = True,
-            appCoreClass = appCoreClass
+            expand       = True
         ))
 
         # Define SW trigger command

--- a/python/AppTop/TopLevel.py
+++ b/python/AppTop/TopLevel.py
@@ -50,6 +50,7 @@ class TopLevel(pr.Device):
             numWaveformBuffers  = 4,
             expand          = True,
             enableTpgMini   = True,
+            appCoreClass    = None,
             **kwargs):
         super().__init__(name=name, description=description, expand=expand, **kwargs)
 
@@ -158,6 +159,7 @@ class TopLevel(pr.Device):
             modeSigGen   = modeSigGen,
             numWaveformBuffers = numWaveformBuffers,
             expand       = True,
+            appCoreClass = appCoreClass
         ))
 
         # Define SW trigger command

--- a/python/AppTop/__init__.py
+++ b/python/AppTop/__init__.py
@@ -3,3 +3,4 @@
 from AppTop.AppTop import *
 from AppTop.AppTopJesd import *
 from AppTop.TopLevel import *
+from AppTop.AppCore  import *


### PR DESCRIPTION
Instead of relying on an external python package called "common" this new method will rely on the developer adding an object which is a sub-class of AppTop.AppCore to the device tree from a higher level python script.

`````
class MyAppCore(AppTop.AppCore):
    ....

self.FpgaTopLevel.AppTop.add(MyAppCore(name='blah'))

`````