### PR TITLE
Fix for AxiDualPortRam generic interface change

### DIFF
--- a/AppHardware/AmcMrLlrfUpConvert/core/LvdsDacLane.vhd
+++ b/AppHardware/AmcMrLlrfUpConvert/core/LvdsDacLane.vhd
@@ -2,7 +2,7 @@
 -- File       : LvdsDacLane.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-01-29
--- Last update: 2017-04-19
+-- Last update: 2019-10-14
 -------------------------------------------------------------------------------
 -- Description:  Single lane arbitrary periodic signal generator
 --               The module contains a AXI-Lite accessible block RAM where the 
@@ -83,9 +83,6 @@ begin
    U_RAM : entity work.AxiDualPortRam
       generic map (
          TPD_G        => TPD_G,
-         BRAM_EN_G    => true,
-         REG_EN_G     => true,
-         MODE_G       => "write-first",
          ADDR_WIDTH_G => ADDR_WIDTH_G,
          DATA_WIDTH_G => 16,
          INIT_G       => "0")

--- a/AppHardware/AmcMrLlrfUpConvert/v2/AmcMrLlrfUpConvertBay1Pinout.xdc
+++ b/AppHardware/AmcMrLlrfUpConvert/v2/AmcMrLlrfUpConvertBay1Pinout.xdc
@@ -50,6 +50,7 @@ set_property -dict { IOSTANDARD LVDS } [get_ports {syncOutP[1][2]}] ; # jesdSync
 set_property -dict { IOSTANDARD LVDS } [get_ports {syncOutN[1][2]}] ; # jesdSyncN[1][1]
 set_property -dict { IOSTANDARD LVDS } [get_ports {syncOutP[1][1]}] ; # jesdSyncP[1][2]
 set_property -dict { IOSTANDARD LVDS } [get_ports {syncOutN[1][1]}] ; # jesdSyncN[1][2]
+set_property UNAVAILABLE_DURING_CALIBRATION TRUE [get_ports {syncOutP[1][1]}]
 
 # LMK and ADC SPI
 set_property -dict { IOSTANDARD LVCMOS25 PULLUP true} [get_ports {jtagPri[1][0]}] ; #spiSdio_io[1]

--- a/AppHardware/RtmDigitalDebug/v2/RtmDigitalDebugV2.vhd
+++ b/AppHardware/RtmDigitalDebug/v2/RtmDigitalDebugV2.vhd
@@ -76,6 +76,7 @@ architecture mapping of RtmDigitalDebugV2 is
    signal userValueOut : slv(31 downto 0);
    signal doutP        : slv(7 downto 0);
    signal doutN        : slv(7 downto 0);
+   signal doutClk      : sl;
    signal cleanClock   : sl;
 
 
@@ -171,6 +172,8 @@ begin
          xDin(7) => rtmLsN(5),
          din     => din);
 
+   doutClk <= not clk(0);
+   
    -------------------------
    -- Digital Output Mapping
    -------------------------         
@@ -180,7 +183,7 @@ begin
          REG_DOUT_EN_G   => REG_DOUT_EN_G,
          REG_DOUT_MODE_G => REG_DOUT_MODE_G)
       port map (
-         clk     => clk(0),             -- Used for REG_DOUT_EN_G(x) = '1')
+         clk     => doutClk,             -- Used for REG_DOUT_EN_G(x) = '1')
          disable => userValueOut(7 downto 0),
          -- Digital Output Interface
          dout    => dout,


### PR DESCRIPTION
MrLlrfUpConvert never migrated to match surf change in AxiDualPortRam generics change.