### PR TITLE
v3.1.4 release candidate

### DIFF
--- a/AmcCarrierCore/core/AmcCarrierPkg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierPkg.vhd
@@ -25,8 +25,8 @@ use lcls_timing_core.TimingPkg.all;
 
 package AmcCarrierPkg is
 
-   -- https://github.com/slaclab/amc-carrier-core/releases/tag/v3.1.3
-   constant AMC_CARRIER_CORE_VERSION_C : slv(31 downto 0) := x"03_01_03_00";
+   -- https://github.com/slaclab/amc-carrier-core/releases/tag/v3.1.4
+   constant AMC_CARRIER_CORE_VERSION_C : slv(31 downto 0) := x"03_01_04_00";
 
    -----------------------------------------------------------
    -- Application: Configurations, Constants and Records Types

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -37,7 +37,7 @@ set family [getFpgaFamily]
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
    if { [SubmoduleCheck {lcls-timing-core} {2.0.0} "mustBeExact" ] < 0 } {exit -1}
    if { [SubmoduleCheck {ruckus}           {2.2.1} "mustBeExact" ] < 0 } {exit -1}
-   if { [SubmoduleCheck {surf}             {2.1.0} "mustBeExact" ] < 0 } {exit -1}
+   if { [SubmoduleCheck {surf}             {2.1.2} "mustBeExact" ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"
    puts "OVERRIDE_SUBMODULE_LOCKS != 0"


### PR DESCRIPTION
### Description
- updating to submodule lock to surf@v2.1.2
  - https://github.com/slaclab/surf/pull/635
- Latest tag release before migrating to lcls-timing-core version3