### PR TITLE
Add delay between YAML load and Init()

### DIFF
--- a/python/AmcCarrierCore/AppTop/_AppTop.py
+++ b/python/AmcCarrierCore/AppTop/_AppTop.py
@@ -152,10 +152,10 @@ class AppTop(pr.Device):
         # Retire any in-flight transactions before starting
         self._root.checkBlocks(recurse=True)
         self.checkBlocks(recurse=True)
-        
+
         # Add delay between YAML load and Init()
         time.sleep(1.0)
-        
+
         # Perform the device init
         self.Init()
 

--- a/python/AmcCarrierCore/AppTop/_AppTop.py
+++ b/python/AmcCarrierCore/AppTop/_AppTop.py
@@ -151,7 +151,11 @@ class AppTop(pr.Device):
 
         # Retire any in-flight transactions before starting
         self._root.checkBlocks(recurse=True)
-
+        self.checkBlocks(recurse=True)
+        
+        # Add delay between YAML load and Init()
+        time.sleep(1.0)
+        
         # Perform the device init
         self.Init()
 


### PR DESCRIPTION
### Description
- we had a problem where we had to load the configuration twice to get the SMURF system to work.
- it helped a single card system, but we still have issues on the second card.
- This adds some settling time between the YAML load and Init() process