### PR TITLE
Updating Vivado Version locks

### DIFF
--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -5,7 +5,7 @@ proc MyVersionCheck { } {
 
    # Get the Vivado version
    set VersionNumber [version -short]
-   set supported "2017.4 2018.1 2018.2 2018.3 2019.1 2019.2"
+   set supported "2018.3 2019.1 2019.2 2020.1"
    set retVar -1
 
    # Generate error message


### PR DESCRIPTION
### Description
- Updated to supported "2018.3 2019.1 2019.2 2020.1"