### PR TITLE
Fix yaml for EvrV2TriggerReg with correct bit width for delay and pul…

### DIFF
--- a/AmcCarrierCore/yaml/AmcCarrierTiming.yaml
+++ b/AmcCarrierCore/yaml/AmcCarrierTiming.yaml
@@ -38,6 +38,13 @@ AmcCarrierTiming: &AmcCarrierTiming
       <<: *EvrV2CoreTriggers
       at:
         offset: 0x00040000
+      children:
+        EvrV2TriggerReg:
+	  children:
+	    Delay:
+	      sizeBits: 19
+	    Width:
+	      sizeBits: 19
     ##################################################
     GthRxAlignCheck:
       <<: *GthRxAlignCheck


### PR DESCRIPTION
…se width

Found that yaml for amc-carrier-core projects uses default from EvrV2TriggerReg rather than value set by generic.  Propagate generic in the yaml.