### PR TITLE
Increasing to 8 number of MPS thresholds for BCM and BLEN

### DIFF
--- a/AppMps/rtl/AppMpsPkg.vhd
+++ b/AppMps/rtl/AppMpsPkg.vhd
@@ -401,12 +401,12 @@ package body AppMpsPkg is
             ret.LCLS2_COUNT_C := 2;
 
             -- Input 0
-            ret.CHAN_CONFIG_C(0).THOLD_COUNT_C := 4;
+            ret.CHAN_CONFIG_C(0).THOLD_COUNT_C := 8;
             ret.CHAN_CONFIG_C(0).IDLE_EN_C     := true;
             ret.CHAN_CONFIG_C(0).BYTE_MAP_C    := 0;
 
             -- Input 16
-            ret.CHAN_CONFIG_C(16).THOLD_COUNT_C := 4;
+            ret.CHAN_CONFIG_C(16).THOLD_COUNT_C := 8;
             ret.CHAN_CONFIG_C(16).IDLE_EN_C     := true;
             ret.CHAN_CONFIG_C(16).BYTE_MAP_C    := 1;
 
@@ -415,22 +415,22 @@ package body AppMpsPkg is
             ret.LCLS2_COUNT_C := 4;
 
             -- Input 0
-            ret.CHAN_CONFIG_C(0).THOLD_COUNT_C := 4;
+            ret.CHAN_CONFIG_C(0).THOLD_COUNT_C := 8;
             ret.CHAN_CONFIG_C(0).IDLE_EN_C     := true;
             ret.CHAN_CONFIG_C(0).BYTE_MAP_C    := 0;
 
             -- Input 16
-            ret.CHAN_CONFIG_C(16).THOLD_COUNT_C := 4;
+            ret.CHAN_CONFIG_C(16).THOLD_COUNT_C := 8;
             ret.CHAN_CONFIG_C(16).IDLE_EN_C     := true;
             ret.CHAN_CONFIG_C(16).BYTE_MAP_C    := 1;
 
             -- Input 5
-            ret.CHAN_CONFIG_C(5).THOLD_COUNT_C := 4;
+            ret.CHAN_CONFIG_C(5).THOLD_COUNT_C := 8;
             ret.CHAN_CONFIG_C(5).IDLE_EN_C     := true;
             ret.CHAN_CONFIG_C(5).BYTE_MAP_C    := 2;
 
             -- Input 21
-            ret.CHAN_CONFIG_C(21).THOLD_COUNT_C := 4;
+            ret.CHAN_CONFIG_C(21).THOLD_COUNT_C := 8;
             ret.CHAN_CONFIG_C(21).IDLE_EN_C     := true;
             ret.CHAN_CONFIG_C(21).BYTE_MAP_C    := 3;
 


### PR DESCRIPTION
Per Jeremy request increased number thresholds to 8 for BCM/BLEN systems