### PR TITLE
Update to AppMpsSalt.vhd for masking off unused RX SALT channels on the ATCA backplane

### DIFF
--- a/AppMps/rtl/AppMpsSalt.vhd
+++ b/AppMps/rtl/AppMpsSalt.vhd
@@ -107,7 +107,7 @@ architecture mapping of AppMpsSalt is
       rollOverEn     => (others => '0'),
       mpsPktCnt      => (others => (others => '0')),
       mpsErrCnt      => (others => (others => '0')),
-      mpsChEnable    => b"000_0000_0111_1111",  -- Only enable the first lower 7 channels
+      mpsChEnable    => (others => '0'),  -- Disable all channels by default
       srobeCnt       => (others => '0'),
       axilReadSlave  => AXI_LITE_READ_SLAVE_INIT_C,
       axilWriteSlave => AXI_LITE_WRITE_SLAVE_INIT_C);

--- a/AppMps/yaml/AppMpsSalt.yaml
+++ b/AppMps/yaml/AppMpsSalt.yaml
@@ -198,6 +198,16 @@ AppMpsSalt: &AppMpsSalt
       sizeBits: 32
       description: Counts the diagnostic strobes
     #########################################################
+    MpsChEnable:
+      at:
+        offset: 0xFEC
+      class: IntField
+      name: MpsChEnable
+      mode: RW
+      lsBit: 0
+      sizeBits: 15
+      description: MPS RX SALT Channel enable bitmask
+    #########################################################
     RollOverEn:
       at:
         offset: 0xFF0


### PR DESCRIPTION
### Description
- adding mpsChEnable bitmask to AppMpsSalt.vhd
- updating AppMpsSalt.yaml with MpsChEnable reg