### PR TITLE
Reentering missing DN application ID 122

### DIFF
--- a/AmcCarrierCore/core/AmcCarrierPkg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierPkg.vhd
@@ -47,7 +47,8 @@ package AmcCarrierPkg is
 
    constant APP_MPS_AN_TYPE_C : AppType := toSlv(120, AppType'length);
    constant APP_MPS_LN_TYPE_C : AppType := toSlv(121, AppType'length);
-
+   constant APP_MPS_DN_TYPE_C : AppType := toSlv(122, AppType'length);  -- MPS Digital node
+   
    -------------------------------------
    -- Common Platform: General Constants
    -------------------------------------


### PR DESCRIPTION
We need to have DN (digital) link node ID to support it