### PR TITLE
adding support for > 2 byte digital APP

### DIFF
--- a/AppMps/rtl/AppMpsSelect.vhd
+++ b/AppMps/rtl/AppMpsSelect.vhd
@@ -126,7 +126,9 @@ begin
       v.mpsSelect.selectAlt := ite(((beamDest and altDestInt) /= 0),'1','0');
 
       -- Digital APP
-      v.mpsSelect.digitalBus(15 downto 0) := diagnosticBus.data(30)(15 downto 0);
+      v.mpsSelect.digitalBus(31 downto 0)  := diagnosticBus.data(30);
+      v.mpsSelect.digitalBus(63 downto 32) := diagnosticBus.data(31);
+
       -- Synchronous Reset
       if (diagnosticRst = '1') then
          v := REG_INIT_C;


### PR DESCRIPTION
### Description
- New LLRF-->BSA/MPS ICD requires 4 bytes (32-bits)
  - (4 fiber links) x (four 2-bit CAV permits per link) = 32-bits

