### PR TITLE
Repurposing the LCLS-II unused 8198 UDP port for BLD/BSSS

### DIFF
--- a/AmcCarrierCore/core/kintexu/AmcCarrierEth.vhd
+++ b/AmcCarrierCore/core/kintexu/AmcCarrierEth.vhd
@@ -17,7 +17,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_unsigned.all;
 use ieee.std_logic_arith.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiLitePkg.all;
@@ -34,62 +33,62 @@ entity AmcCarrierEth is
       TPD_G                 : time     := 1 ns;
       RSSI_ILEAVE_EN_G      : boolean  := false;
       RTM_ETH_G             : boolean  := false;
-      DEBUG_PATH_SELECT_G   : boolean  := false;    -- false = UDP[port=8193], true = UDP[port=8194]
-      ETH_USR_FRAME_LIMIT_G : positive := 4096);    -- 4kB
+      DEBUG_PATH_SELECT_G   : boolean  := false;  -- false = UDP[port=8193], true = UDP[port=8194]
+      ETH_USR_FRAME_LIMIT_G : positive := 4096);  -- 4kB
    port (
       -- Local Configuration and status
-      localMac             : in  slv(47 downto 0);  --  big-Endian configuration
-      localIp              : in  slv(31 downto 0);  --  big-Endian configuration
-      ethPhyReady          : out sl;
+      localMac              : in  slv(47 downto 0);  --  big-Endian configuration
+      localIp               : in  slv(31 downto 0);  --  big-Endian configuration
+      ethPhyReady           : out sl;
       -- Master AXI-Lite Interface
-      mAxilReadMasters     : out AxiLiteReadMasterArray(1 downto 0);
-      mAxilReadSlaves      : in  AxiLiteReadSlaveArray(1 downto 0);
-      mAxilWriteMasters    : out AxiLiteWriteMasterArray(1 downto 0);
-      mAxilWriteSlaves     : in  AxiLiteWriteSlaveArray(1 downto 0);
+      mAxilReadMasters      : out AxiLiteReadMasterArray(1 downto 0);
+      mAxilReadSlaves       : in  AxiLiteReadSlaveArray(1 downto 0);
+      mAxilWriteMasters     : out AxiLiteWriteMasterArray(1 downto 0);
+      mAxilWriteSlaves      : in  AxiLiteWriteSlaveArray(1 downto 0);
       -- AXI-Lite Interface
-      axilClk              : in  sl;
-      axilRst              : in  sl;
-      axilReadMaster       : in  AxiLiteReadMasterType;
-      axilReadSlave        : out AxiLiteReadSlaveType;
-      axilWriteMaster      : in  AxiLiteWriteMasterType;
-      axilWriteSlave       : out AxiLiteWriteSlaveType;
+      axilClk               : in  sl;
+      axilRst               : in  sl;
+      axilReadMaster        : in  AxiLiteReadMasterType;
+      axilReadSlave         : out AxiLiteReadSlaveType;
+      axilWriteMaster       : in  AxiLiteWriteMasterType;
+      axilWriteSlave        : out AxiLiteWriteSlaveType;
       -- BSA Ethernet Interface
-      obBsaMasters         : in  AxiStreamMasterArray(3 downto 0);
-      obBsaSlaves          : out AxiStreamSlaveArray(3 downto 0);
-      ibBsaMasters         : out AxiStreamMasterArray(3 downto 0);
-      ibBsaSlaves          : in  AxiStreamSlaveArray(3 downto 0);
+      obBsaMasters          : in  AxiStreamMasterArray(3 downto 0);
+      obBsaSlaves           : out AxiStreamSlaveArray(3 downto 0);
+      ibBsaMasters          : out AxiStreamMasterArray(3 downto 0);
+      ibBsaSlaves           : in  AxiStreamSlaveArray(3 downto 0);
       -- Timing ETH MSG Interface
-      obTimingEthMsgMaster : in  AxiStreamMasterType;
-      obTimingEthMsgSlave  : out AxiStreamSlaveType;
-      ibTimingEthMsgMaster : out AxiStreamMasterType;
-      ibTimingEthMsgSlave  : in  AxiStreamSlaveType;
+      obTimingEthMsgMasters : in  AxiStreamMasterArray(1 downto 0);
+      obTimingEthMsgSlaves  : out AxiStreamSlaveArray(1 downto 0);
+      ibTimingEthMsgMasters : out AxiStreamMasterArray(1 downto 0);
+      ibTimingEthMsgSlaves  : in  AxiStreamSlaveArray(1 downto 0);
       ----------------------
       -- Top Level Interface
       ----------------------
       -- Application Debug Interface
-      obAppDebugMaster     : in  AxiStreamMasterType;
-      obAppDebugSlave      : out AxiStreamSlaveType;
-      ibAppDebugMaster     : out AxiStreamMasterType;
-      ibAppDebugSlave      : in  AxiStreamSlaveType;
+      obAppDebugMaster      : in  AxiStreamMasterType;
+      obAppDebugSlave       : out AxiStreamSlaveType;
+      ibAppDebugMaster      : out AxiStreamMasterType;
+      ibAppDebugSlave       : in  AxiStreamSlaveType;
       -- Backplane Messaging Interface
-      obBpMsgClientMaster  : in  AxiStreamMasterType;
-      obBpMsgClientSlave   : out AxiStreamSlaveType;
-      ibBpMsgClientMaster  : out AxiStreamMasterType;
-      ibBpMsgClientSlave   : in  AxiStreamSlaveType;
-      obBpMsgServerMaster  : in  AxiStreamMasterType;
-      obBpMsgServerSlave   : out AxiStreamSlaveType;
-      ibBpMsgServerMaster  : out AxiStreamMasterType;
-      ibBpMsgServerSlave   : in  AxiStreamSlaveType;
+      obBpMsgClientMaster   : in  AxiStreamMasterType;
+      obBpMsgClientSlave    : out AxiStreamSlaveType;
+      ibBpMsgClientMaster   : out AxiStreamMasterType;
+      ibBpMsgClientSlave    : in  AxiStreamSlaveType;
+      obBpMsgServerMaster   : in  AxiStreamMasterType;
+      obBpMsgServerSlave    : out AxiStreamSlaveType;
+      ibBpMsgServerMaster   : out AxiStreamMasterType;
+      ibBpMsgServerSlave    : in  AxiStreamSlaveType;
       ----------------
       -- Core Ports --
       ----------------
       -- ETH Ports
-      ethRxP               : in  slv(3 downto 0);
-      ethRxN               : in  slv(3 downto 0);
-      ethTxP               : out slv(3 downto 0);
-      ethTxN               : out slv(3 downto 0);
-      ethClkP              : in  sl;
-      ethClkN              : in  sl);
+      ethRxP                : in  slv(3 downto 0);
+      ethRxN                : in  slv(3 downto 0);
+      ethTxP                : out slv(3 downto 0);
+      ethTxN                : out slv(3 downto 0);
+      ethClkP               : in  sl;
+      ethClkN               : in  sl);
 end AmcCarrierEth;
 
 architecture mapping of AmcCarrierEth is
@@ -127,7 +126,7 @@ architecture mapping of AmcCarrierEth is
       UDP_SRV_RSSI1_IDX_C       => 8194,  -- Legacy Non-interleaved RSSI for bulk data transfer
       UDP_SRV_BP_MGS_IDX_C      => 8195,  -- Backplane Messaging
       UDP_SRV_TIMING_IDX_C      => 8197,  -- Timing ASYNC Messaging
-      UDP_SRV_RSSI_ILEAVE_IDX_C => 8198);  -- Interleaved RSSI
+      UDP_SRV_RSSI_ILEAVE_IDX_C => 8198);  -- ite(RSSI_ILEAVE_EN_G, Interleaved RSSI, BLD/BSSS)
 
    ------------------------------------------
    --     UDP Client Configurations        --
@@ -422,8 +421,13 @@ begin
       axilReadSlaves(AXI_RSSI_ILEAVE_INDEX_C)  <= AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       axilWriteSlaves(AXI_RSSI_ILEAVE_INDEX_C) <= AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
 
-      obServerSlaves(UDP_SRV_RSSI_ILEAVE_IDX_C)  <= AXI_STREAM_SLAVE_FORCE_C;
-      ibServerMasters(UDP_SRV_RSSI_ILEAVE_IDX_C) <= AXI_STREAM_MASTER_INIT_C;
+      ----------------------
+      -- BLD/BSSS MSG Server
+      ----------------------
+      ibServerMasters(UDP_SRV_RSSI_ILEAVE_IDX_C) <= obTimingEthMsgMasters(1);
+      obTimingEthMsgSlaves(1)                    <= ibServerSlaves(UDP_SRV_RSSI_ILEAVE_IDX_C);
+      ibTimingEthMsgMasters(1)                   <= obServerMasters(UDP_SRV_RSSI_ILEAVE_IDX_C);
+      obServerSlaves(UDP_SRV_RSSI_ILEAVE_IDX_C)  <= ibTimingEthMsgSlaves(1);
 
    end generate;
 
@@ -471,6 +475,9 @@ begin
 
       obServerSlaves(UDP_SRV_RSSI1_IDX_C)  <= AXI_STREAM_SLAVE_FORCE_C;
       ibServerMasters(UDP_SRV_RSSI1_IDX_C) <= AXI_STREAM_MASTER_INIT_C;
+
+      obTimingEthMsgSlaves(1)  <= AXI_STREAM_SLAVE_FORCE_C;
+      ibTimingEthMsgMasters(1) <= AXI_STREAM_MASTER_INIT_C;
 
    end generate;
 
@@ -523,10 +530,10 @@ begin
    --------------------
    -- Timing MSG Server
    --------------------
-   ibServerMasters(UDP_SRV_TIMING_IDX_C) <= obTimingEthMsgMaster;
-   obTimingEthMsgSlave                   <= ibServerSlaves(UDP_SRV_TIMING_IDX_C);
-   ibTimingEthMsgMaster                  <= obServerMasters(UDP_SRV_TIMING_IDX_C);
-   obServerSlaves(UDP_SRV_TIMING_IDX_C)  <= ibTimingEthMsgSlave;
+   ibServerMasters(UDP_SRV_TIMING_IDX_C) <= obTimingEthMsgMasters(0);
+   obTimingEthMsgSlaves(0)               <= ibServerSlaves(UDP_SRV_TIMING_IDX_C);
+   ibTimingEthMsgMasters(0)              <= obServerMasters(UDP_SRV_TIMING_IDX_C);
+   obServerSlaves(UDP_SRV_TIMING_IDX_C)  <= ibTimingEthMsgSlaves(0);
 
    ----------------------
    -- BP Messenger Client

--- a/AmcCarrierCore/core/kintexuplus/AmcCarrierEth.vhd
+++ b/AmcCarrierCore/core/kintexuplus/AmcCarrierEth.vhd
@@ -17,7 +17,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_unsigned.all;
 use ieee.std_logic_arith.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiLitePkg.all;
@@ -34,62 +33,62 @@ entity AmcCarrierEth is
       TPD_G                 : time     := 1 ns;
       RSSI_ILEAVE_EN_G      : boolean  := false;
       RTM_ETH_G             : boolean  := false;
-      DEBUG_PATH_SELECT_G   : boolean  := false;    -- false = UDP[port=8193], true = UDP[port=8194]
-      ETH_USR_FRAME_LIMIT_G : positive := 4096);    -- 4kB
+      DEBUG_PATH_SELECT_G   : boolean  := false;  -- false = UDP[port=8193], true = UDP[port=8194]
+      ETH_USR_FRAME_LIMIT_G : positive := 4096);  -- 4kB
    port (
       -- Local Configuration and status
-      localMac             : in  slv(47 downto 0);  --  big-Endian configuration
-      localIp              : in  slv(31 downto 0);  --  big-Endian configuration
-      ethPhyReady          : out sl;
+      localMac              : in  slv(47 downto 0);  --  big-Endian configuration
+      localIp               : in  slv(31 downto 0);  --  big-Endian configuration
+      ethPhyReady           : out sl;
       -- Master AXI-Lite Interface
-      mAxilReadMasters     : out AxiLiteReadMasterArray(1 downto 0);
-      mAxilReadSlaves      : in  AxiLiteReadSlaveArray(1 downto 0);
-      mAxilWriteMasters    : out AxiLiteWriteMasterArray(1 downto 0);
-      mAxilWriteSlaves     : in  AxiLiteWriteSlaveArray(1 downto 0);
+      mAxilReadMasters      : out AxiLiteReadMasterArray(1 downto 0);
+      mAxilReadSlaves       : in  AxiLiteReadSlaveArray(1 downto 0);
+      mAxilWriteMasters     : out AxiLiteWriteMasterArray(1 downto 0);
+      mAxilWriteSlaves      : in  AxiLiteWriteSlaveArray(1 downto 0);
       -- AXI-Lite Interface
-      axilClk              : in  sl;
-      axilRst              : in  sl;
-      axilReadMaster       : in  AxiLiteReadMasterType;
-      axilReadSlave        : out AxiLiteReadSlaveType;
-      axilWriteMaster      : in  AxiLiteWriteMasterType;
-      axilWriteSlave       : out AxiLiteWriteSlaveType;
+      axilClk               : in  sl;
+      axilRst               : in  sl;
+      axilReadMaster        : in  AxiLiteReadMasterType;
+      axilReadSlave         : out AxiLiteReadSlaveType;
+      axilWriteMaster       : in  AxiLiteWriteMasterType;
+      axilWriteSlave        : out AxiLiteWriteSlaveType;
       -- BSA Ethernet Interface
-      obBsaMasters         : in  AxiStreamMasterArray(3 downto 0);
-      obBsaSlaves          : out AxiStreamSlaveArray(3 downto 0);
-      ibBsaMasters         : out AxiStreamMasterArray(3 downto 0);
-      ibBsaSlaves          : in  AxiStreamSlaveArray(3 downto 0);
+      obBsaMasters          : in  AxiStreamMasterArray(3 downto 0);
+      obBsaSlaves           : out AxiStreamSlaveArray(3 downto 0);
+      ibBsaMasters          : out AxiStreamMasterArray(3 downto 0);
+      ibBsaSlaves           : in  AxiStreamSlaveArray(3 downto 0);
       -- Timing ETH MSG Interface
-      obTimingEthMsgMaster : in  AxiStreamMasterType;
-      obTimingEthMsgSlave  : out AxiStreamSlaveType;
-      ibTimingEthMsgMaster : out AxiStreamMasterType;
-      ibTimingEthMsgSlave  : in  AxiStreamSlaveType;
+      obTimingEthMsgMasters : in  AxiStreamMasterArray(1 downto 0);
+      obTimingEthMsgSlaves  : out AxiStreamSlaveArray(1 downto 0);
+      ibTimingEthMsgMasters : out AxiStreamMasterArray(1 downto 0);
+      ibTimingEthMsgSlaves  : in  AxiStreamSlaveArray(1 downto 0);
       ----------------------
       -- Top Level Interface
       ----------------------
       -- Application Debug Interface
-      obAppDebugMaster     : in  AxiStreamMasterType;
-      obAppDebugSlave      : out AxiStreamSlaveType;
-      ibAppDebugMaster     : out AxiStreamMasterType;
-      ibAppDebugSlave      : in  AxiStreamSlaveType;
+      obAppDebugMaster      : in  AxiStreamMasterType;
+      obAppDebugSlave       : out AxiStreamSlaveType;
+      ibAppDebugMaster      : out AxiStreamMasterType;
+      ibAppDebugSlave       : in  AxiStreamSlaveType;
       -- Backplane Messaging Interface
-      obBpMsgClientMaster  : in  AxiStreamMasterType;
-      obBpMsgClientSlave   : out AxiStreamSlaveType;
-      ibBpMsgClientMaster  : out AxiStreamMasterType;
-      ibBpMsgClientSlave   : in  AxiStreamSlaveType;
-      obBpMsgServerMaster  : in  AxiStreamMasterType;
-      obBpMsgServerSlave   : out AxiStreamSlaveType;
-      ibBpMsgServerMaster  : out AxiStreamMasterType;
-      ibBpMsgServerSlave   : in  AxiStreamSlaveType;
+      obBpMsgClientMaster   : in  AxiStreamMasterType;
+      obBpMsgClientSlave    : out AxiStreamSlaveType;
+      ibBpMsgClientMaster   : out AxiStreamMasterType;
+      ibBpMsgClientSlave    : in  AxiStreamSlaveType;
+      obBpMsgServerMaster   : in  AxiStreamMasterType;
+      obBpMsgServerSlave    : out AxiStreamSlaveType;
+      ibBpMsgServerMaster   : out AxiStreamMasterType;
+      ibBpMsgServerSlave    : in  AxiStreamSlaveType;
       ----------------
       -- Core Ports --
       ----------------
       -- ETH Ports
-      ethRxP               : in  slv(3 downto 0);
-      ethRxN               : in  slv(3 downto 0);
-      ethTxP               : out slv(3 downto 0);
-      ethTxN               : out slv(3 downto 0);
-      ethClkP              : in  sl;
-      ethClkN              : in  sl);
+      ethRxP                : in  slv(3 downto 0);
+      ethRxN                : in  slv(3 downto 0);
+      ethTxP                : out slv(3 downto 0);
+      ethTxN                : out slv(3 downto 0);
+      ethClkP               : in  sl;
+      ethClkN               : in  sl);
 end AmcCarrierEth;
 
 architecture mapping of AmcCarrierEth is
@@ -127,7 +126,7 @@ architecture mapping of AmcCarrierEth is
       UDP_SRV_RSSI1_IDX_C       => 8194,  -- Legacy Non-interleaved RSSI for bulk data transfer
       UDP_SRV_BP_MGS_IDX_C      => 8195,  -- Backplane Messaging
       UDP_SRV_TIMING_IDX_C      => 8197,  -- Timing ASYNC Messaging
-      UDP_SRV_RSSI_ILEAVE_IDX_C => 8198);  -- Interleaved RSSI
+      UDP_SRV_RSSI_ILEAVE_IDX_C => 8198);  -- ite(RSSI_ILEAVE_EN_G, Interleaved RSSI, BLD/BSSS)
 
    ------------------------------------------
    --     UDP Client Configurations        --
@@ -422,8 +421,13 @@ begin
       axilReadSlaves(AXI_RSSI_ILEAVE_INDEX_C)  <= AXI_LITE_READ_SLAVE_EMPTY_OK_C;
       axilWriteSlaves(AXI_RSSI_ILEAVE_INDEX_C) <= AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
 
-      obServerSlaves(UDP_SRV_RSSI_ILEAVE_IDX_C)  <= AXI_STREAM_SLAVE_FORCE_C;
-      ibServerMasters(UDP_SRV_RSSI_ILEAVE_IDX_C) <= AXI_STREAM_MASTER_INIT_C;
+      ----------------------
+      -- BLD/BSSS MSG Server
+      ----------------------
+      ibServerMasters(UDP_SRV_RSSI_ILEAVE_IDX_C) <= obTimingEthMsgMasters(1);
+      obTimingEthMsgSlaves(1)                    <= ibServerSlaves(UDP_SRV_RSSI_ILEAVE_IDX_C);
+      ibTimingEthMsgMasters(1)                   <= obServerMasters(UDP_SRV_RSSI_ILEAVE_IDX_C);
+      obServerSlaves(UDP_SRV_RSSI_ILEAVE_IDX_C)  <= ibTimingEthMsgSlaves(1);
 
    end generate;
 
@@ -471,6 +475,9 @@ begin
 
       obServerSlaves(UDP_SRV_RSSI1_IDX_C)  <= AXI_STREAM_SLAVE_FORCE_C;
       ibServerMasters(UDP_SRV_RSSI1_IDX_C) <= AXI_STREAM_MASTER_INIT_C;
+
+      obTimingEthMsgSlaves(1)  <= AXI_STREAM_SLAVE_FORCE_C;
+      ibTimingEthMsgMasters(1) <= AXI_STREAM_MASTER_INIT_C;
 
    end generate;
 
@@ -523,10 +530,10 @@ begin
    --------------------
    -- Timing MSG Server
    --------------------
-   ibServerMasters(UDP_SRV_TIMING_IDX_C) <= obTimingEthMsgMaster;
-   obTimingEthMsgSlave                   <= ibServerSlaves(UDP_SRV_TIMING_IDX_C);
-   ibTimingEthMsgMaster                  <= obServerMasters(UDP_SRV_TIMING_IDX_C);
-   obServerSlaves(UDP_SRV_TIMING_IDX_C)  <= ibTimingEthMsgSlave;
+   ibServerMasters(UDP_SRV_TIMING_IDX_C) <= obTimingEthMsgMasters(0);
+   obTimingEthMsgSlaves(0)               <= ibServerSlaves(UDP_SRV_TIMING_IDX_C);
+   ibTimingEthMsgMasters(0)              <= obServerMasters(UDP_SRV_TIMING_IDX_C);
+   obServerSlaves(UDP_SRV_TIMING_IDX_C)  <= ibTimingEthMsgSlaves(0);
 
    ----------------------
    -- BP Messenger Client

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
@@ -49,13 +49,13 @@ entity AmcCarrierCore is
       TIME_GEN_EXTREF_G      : boolean  := false;  -- false = normal application, true = timing generator using external reference
       DISABLE_TIME_GT_G      : boolean  := false;  -- false = normal application, true = doesn't build the Timing GT
       CORE_TRIGGERS_G        : natural  := 16;
-      TRIG_PIPE_G            : natural  := 0;      -- no trigger pipeline by default
+      TRIG_PIPE_G            : natural  := 0;  -- no trigger pipeline by default
       USE_TPGMINI_G          : boolean  := true;   -- build TPG Mini by default
-      CLKSEL_MODE_G          : string   := "SELECT"; -- "LCLSI","LCLSII"
+      CLKSEL_MODE_G          : string   := "SELECT";  -- "LCLSI","LCLSII"
       STREAM_L1_G            : boolean  := true;
       AXIL_RINGB_G           : boolean  := true;
       ASYNC_G                : boolean  := true;
-      FSBL_G                 : boolean  := false); -- false = Normal Operation, true = First Stage Boot loader
+      FSBL_G                 : boolean  := false);  -- false = Normal Operation, true = First Stage Boot loader
    port (
       -----------------------
       -- Core Ports to AppTop
@@ -376,10 +376,10 @@ begin
          DISABLE_TIME_GT_G => DISABLE_TIME_GT_G,
          CORE_TRIGGERS_G   => CORE_TRIGGERS_G,
          TRIG_PIPE_G       => TRIG_PIPE_G,
-	 CLKSEL_MODE_G     => CLKSEL_MODE_G,
-	 STREAM_L1_G       => STREAM_L1_G,
-	 AXIL_RINGB_G      => AXIL_RINGB_G,
-	 ASYNC_G           => ASYNC_G,
+         CLKSEL_MODE_G     => CLKSEL_MODE_G,
+         STREAM_L1_G       => STREAM_L1_G,
+         AXIL_RINGB_G      => AXIL_RINGB_G,
+         ASYNC_G           => ASYNC_G,
          USE_TPGMINI_G     => USE_TPGMINI_G)
       port map (
          stableClk            => fabClk,

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
@@ -192,15 +192,15 @@ architecture mapping of AmcCarrierCore is
    signal axiReadMaster  : AxiReadMasterType;
    signal axiReadSlave   : AxiReadSlaveType;
 
-   signal obBsaMasters : AxiStreamMasterArray(3 downto 0);
-   signal obBsaSlaves  : AxiStreamSlaveArray(3 downto 0);
-   signal ibBsaMasters : AxiStreamMasterArray(3 downto 0);
-   signal ibBsaSlaves  : AxiStreamSlaveArray(3 downto 0);
+   signal obBsaMasters : AxiStreamMasterArray(3 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal obBsaSlaves  : AxiStreamSlaveArray(3 downto 0)  := (others => AXI_STREAM_SLAVE_FORCE_C);
+   signal ibBsaMasters : AxiStreamMasterArray(3 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal ibBsaSlaves  : AxiStreamSlaveArray(3 downto 0)  := (others => AXI_STREAM_SLAVE_FORCE_C);
 
-   signal obTimingEthMsgMasters : AxiStreamMasterArray(1 downto 0);
-   signal obTimingEthMsgSlaves  : AxiStreamSlaveArray(1 downto 0);
-   signal ibTimingEthMsgMasters : AxiStreamMasterArray(1 downto 0);
-   signal ibTimingEthMsgSlaves  : AxiStreamSlaveArray(1 downto 0);
+   signal obTimingEthMsgMasters : AxiStreamMasterArray(1 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal obTimingEthMsgSlaves  : AxiStreamSlaveArray(1 downto 0)  := (others => AXI_STREAM_SLAVE_FORCE_C);
+   signal ibTimingEthMsgMasters : AxiStreamMasterArray(1 downto 0) := (others => AXI_STREAM_MASTER_INIT_C);
+   signal ibTimingEthMsgSlaves  : AxiStreamSlaveArray(1 downto 0)  := (others => AXI_STREAM_SLAVE_FORCE_C);
 
    signal gtClk   : sl;
    signal fabClk  : sl;
@@ -472,8 +472,10 @@ begin
          -- Timing ETH MSG Interface (axilClk domain)
          obEthMsgMaster       => obTimingEthMsgMasters(1),
          obEthMsgSlave        => obTimingEthMsgSlaves(1),
-         ibEthMsgMaster       => ibTimingEthMsgMasters(1),
-         ibEthMsgSlave        => ibTimingEthMsgSlaves(1));
+--       ibEthMsgMaster       => ibTimingEthMsgMasters(1),
+--       ibEthMsgSlave        => ibTimingEthMsgSlaves(1));
+         ibEthMsgMaster       => AXI_STREAM_MASTER_INIT_C,
+         ibEthMsgSlave        => open);
 
    ------------------
    -- DDR Memory Core

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
@@ -15,7 +15,6 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-
 library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiStreamPkg.all;
@@ -198,12 +197,10 @@ architecture mapping of AmcCarrierCore is
    signal ibBsaMasters : AxiStreamMasterArray(3 downto 0);
    signal ibBsaSlaves  : AxiStreamSlaveArray(3 downto 0);
 
-   signal obTimingEthMsgMaster  : AxiStreamMasterType;
-   signal obTimingEthMsgSlave   : AxiStreamSlaveType;
-   signal ibTimingEthMsgMaster  : AxiStreamMasterType;
-   signal ibTimingEthMsgSlave   : AxiStreamSlaveType;
-   signal intTimingEthMsgMaster : AxiStreamMasterType;
-   signal intTimingEthMsgSlave  : AxiStreamSlaveType;
+   signal obTimingEthMsgMasters : AxiStreamMasterArray(1 downto 0);
+   signal obTimingEthMsgSlaves  : AxiStreamSlaveArray(1 downto 0);
+   signal ibTimingEthMsgMasters : AxiStreamMasterArray(1 downto 0);
+   signal ibTimingEthMsgSlaves  : AxiStreamSlaveArray(1 downto 0);
 
    signal gtClk   : sl;
    signal fabClk  : sl;
@@ -216,6 +213,9 @@ architecture mapping of AmcCarrierCore is
    signal auxPwrL : sl;
 
 begin
+
+   assert (RSSI_ILEAVE_EN_G = false) or (RSSI_ILEAVE_EN_G and (DISABLE_BSA_G = false) and (DISABLE_BLD_G = false))
+      report "RSSI Interleave + BSA or BLD is NOT supported" severity failure;
 
    -- Secondary AMC's Auxiliary Power (Default to allows active for the time being)
    -- Note: Install R1063 if you want the FPGA to control AUX power
@@ -312,58 +312,58 @@ begin
          ETH_USR_FRAME_LIMIT_G => ETH_USR_FRAME_LIMIT_G)
       port map (
          -- Local Configuration
-         localMac             => localMac,
-         localIp              => localIp,
-         ethPhyReady          => ethLinkUp,
+         localMac              => localMac,
+         localIp               => localIp,
+         ethPhyReady           => ethLinkUp,
          -- Master AXI-Lite Interface
-         mAxilReadMasters     => axilReadMasters,
-         mAxilReadSlaves      => axilReadSlaves,
-         mAxilWriteMasters    => axilWriteMasters,
-         mAxilWriteSlaves     => axilWriteSlaves,
+         mAxilReadMasters      => axilReadMasters,
+         mAxilReadSlaves       => axilReadSlaves,
+         mAxilWriteMasters     => axilWriteMasters,
+         mAxilWriteSlaves      => axilWriteSlaves,
          -- AXI-Lite Interface
-         axilClk              => axilClk,
-         axilRst              => axilRst,
-         axilReadMaster       => ethReadMaster,
-         axilReadSlave        => ethReadSlave,
-         axilWriteMaster      => ethWriteMaster,
-         axilWriteSlave       => ethWriteSlave,
+         axilClk               => axilClk,
+         axilRst               => axilRst,
+         axilReadMaster        => ethReadMaster,
+         axilReadSlave         => ethReadSlave,
+         axilWriteMaster       => ethWriteMaster,
+         axilWriteSlave        => ethWriteSlave,
          -- BSA Ethernet Interface
-         obBsaMasters         => obBsaMasters,
-         obBsaSlaves          => obBsaSlaves,
-         ibBsaMasters         => ibBsaMasters,
-         ibBsaSlaves          => ibBsaSlaves,
+         obBsaMasters          => obBsaMasters,
+         obBsaSlaves           => obBsaSlaves,
+         ibBsaMasters          => ibBsaMasters,
+         ibBsaSlaves           => ibBsaSlaves,
          -- Timing ETH MSG Interface
-         obTimingEthMsgMaster => obTimingEthMsgMaster,
-         obTimingEthMsgSlave  => obTimingEthMsgSlave,
-         ibTimingEthMsgMaster => ibTimingEthMsgMaster,
-         ibTimingEthMsgSlave  => ibTimingEthMsgSlave,
+         obTimingEthMsgMasters => obTimingEthMsgMasters,
+         obTimingEthMsgSlaves  => obTimingEthMsgSlaves,
+         ibTimingEthMsgMasters => ibTimingEthMsgMasters,
+         ibTimingEthMsgSlaves  => ibTimingEthMsgSlaves,
          ----------------------
          -- Top Level Interface
          ----------------------
          -- Application Debug Interface
-         obAppDebugMaster     => obAppDebugMaster,
-         obAppDebugSlave      => obAppDebugSlave,
-         ibAppDebugMaster     => ibAppDebugMaster,
-         ibAppDebugSlave      => ibAppDebugSlave,
+         obAppDebugMaster      => obAppDebugMaster,
+         obAppDebugSlave       => obAppDebugSlave,
+         ibAppDebugMaster      => ibAppDebugMaster,
+         ibAppDebugSlave       => ibAppDebugSlave,
          -- Backplane Messaging Interface
-         obBpMsgClientMaster  => obBpMsgClientMaster,
-         obBpMsgClientSlave   => obBpMsgClientSlave,
-         ibBpMsgClientMaster  => ibBpMsgClientMaster,
-         ibBpMsgClientSlave   => ibBpMsgClientSlave,
-         obBpMsgServerMaster  => obBpMsgServerMaster,
-         obBpMsgServerSlave   => obBpMsgServerSlave,
-         ibBpMsgServerMaster  => ibBpMsgServerMaster,
-         ibBpMsgServerSlave   => ibBpMsgServerSlave,
+         obBpMsgClientMaster   => obBpMsgClientMaster,
+         obBpMsgClientSlave    => obBpMsgClientSlave,
+         ibBpMsgClientMaster   => ibBpMsgClientMaster,
+         ibBpMsgClientSlave    => ibBpMsgClientSlave,
+         obBpMsgServerMaster   => obBpMsgServerMaster,
+         obBpMsgServerSlave    => obBpMsgServerSlave,
+         ibBpMsgServerMaster   => ibBpMsgServerMaster,
+         ibBpMsgServerSlave    => ibBpMsgServerSlave,
          ----------------
          -- Core Ports --
          ----------------
          -- ETH Ports
-         ethRxP               => ethRxP,
-         ethRxN               => ethRxN,
-         ethTxP               => ethTxP,
-         ethTxN               => ethTxN,
-         ethClkP              => ethClkP,
-         ethClkN              => ethClkN);
+         ethRxP                => ethRxP,
+         ethRxN                => ethRxN,
+         ethTxP                => ethTxP,
+         ethTxN                => ethTxN,
+         ethClkP               => ethClkP,
+         ethClkN               => ethClkN);
 
    --------------
    -- Timing Core
@@ -392,10 +392,10 @@ begin
          axilWriteMaster      => timingWriteMaster,
          axilWriteSlave       => timingWriteSlave,
          -- Timing ETH MSG Interface (axilClk domain)
-         obTimingEthMsgMaster => intTimingEthMsgMaster,
-         obTimingEthMsgSlave  => intTimingEthMsgSlave,
-         ibTimingEthMsgMaster => ibTimingEthMsgMaster,
-         ibTimingEthMsgSlave  => ibTimingEthMsgSlave,
+         obTimingEthMsgMaster => obTimingEthMsgMasters(0),
+         obTimingEthMsgSlave  => obTimingEthMsgSlaves(0),
+         ibTimingEthMsgMaster => ibTimingEthMsgMasters(0),
+         ibTimingEthMsgSlave  => ibTimingEthMsgSlaves(0),
          ----------------------
          -- Top Level Interface
          ----------------------
@@ -470,10 +470,10 @@ begin
          obAppWaveformMasters => obAppWaveformMasters,
          obAppWaveformSlaves  => obAppWaveformSlaves,
          -- Timing ETH MSG Interface (axilClk domain)
-         ibEthMsgMaster       => intTimingEthMsgMaster,
-         ibEthMsgSlave        => intTimingEthMsgSlave,
-         obEthMsgMaster       => obTimingEthMsgMaster,
-         obEthMsgSlave        => obTimingEthMsgSlave);
+         ibEthMsgMaster       => obTimingEthMsgMasters(1),
+         ibEthMsgSlave        => obTimingEthMsgSlaves(1),
+         obEthMsgMaster       => ibTimingEthMsgMasters(1),
+         obEthMsgSlave        => ibTimingEthMsgSlaves(1));
 
    ------------------
    -- DDR Memory Core

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
@@ -470,10 +470,10 @@ begin
          obAppWaveformMasters => obAppWaveformMasters,
          obAppWaveformSlaves  => obAppWaveformSlaves,
          -- Timing ETH MSG Interface (axilClk domain)
-         ibEthMsgMaster       => obTimingEthMsgMasters(1),
-         ibEthMsgSlave        => obTimingEthMsgSlaves(1),
-         obEthMsgMaster       => ibTimingEthMsgMasters(1),
-         obEthMsgSlave        => ibTimingEthMsgSlaves(1));
+         obEthMsgMaster       => obTimingEthMsgMasters(1),
+         obEthMsgSlave        => obTimingEthMsgSlaves(1),
+         ibEthMsgMaster       => ibTimingEthMsgMasters(1),
+         ibEthMsgSlave        => ibTimingEthMsgSlaves(1));
 
    ------------------
    -- DDR Memory Core

--- a/BsaCore/rtl/BsaAccumulator.vhd
+++ b/BsaCore/rtl/BsaAccumulator.vhd
@@ -146,7 +146,7 @@ architecture rtl of BsaAccumulator is
    --  Vivado "optimizes" the DSP48E2 and breaks the rules (REQP-1667)
    attribute keep_hierarchy : string;
    attribute keep_hierarchy of U_SUM : label is "yes";
-   
+
 begin
 
    -- Maybe pass bsaDone on tUser so that we can track when it gets to ram.


### PR DESCRIPTION
### Description
- RSSI interleaved mode is not used in LCLS-II applciation
  - This means that it is an "unused" UDP port 
  - SMURF SO is the only application that uses this RSSI interleaved mode (non-LCLS-II application)
- This pull request keeps the UDP port 8197 (tprPattern) the same
- But moves the bldDriver & bsssDriver to UDP port 8198 
- This changed was proposed to Kukhee during a meeting with him.  
- This PR is intended to communicate the changes to Matt Weaver.