### PR TITLE
Performance and Resource Optimization Updates

### DIFF
--- a/AmcCarrierCore/core/AmcCarrierBsa.vhd
+++ b/AmcCarrierCore/core/AmcCarrierBsa.vhd
@@ -169,7 +169,7 @@ architecture mapping of AmcCarrierBsa is
    signal waveform1AxiReadSlave   : AxiReadSlaveType   := AXI_READ_SLAVE_INIT_C;
 
    signal intEthMsgMaster : AxiStreamMasterArray(1 downto 0) := (others=>AXI_STREAM_MASTER_INIT_C);
-   signal intEthMsgSlave  : AxiStreamSlaveArray (1 downto 0) := (others=>AXI_STREAM_SLAVE_INIT_C);
+   signal intEthMsgSlave  : AxiStreamSlaveArray (1 downto 0) := (others=>AXI_STREAM_SLAVE_FORCE_C);
 
 begin
 
@@ -180,7 +180,7 @@ begin
       axiWriteMaster      <= AXI_WRITE_MASTER_INIT_C;
       axiReadMaster       <= AXI_READ_MASTER_INIT_C;
       obBsaMasters        <= (others => AXI_STREAM_MASTER_INIT_C);
-      ibBsaSlaves         <= (others => AXI_STREAM_SLAVE_INIT_C);
+      ibBsaSlaves         <= (others => AXI_STREAM_SLAVE_FORCE_C);
       obAppWaveformSlaves <= WAVEFORM_SLAVE_ARRAY_INIT_C;
    end generate FSBL_GEN;
 
@@ -383,7 +383,7 @@ begin
                ibEthMsgSlave   => intEthMsgSlave (0),
                obEthMsgMaster  => intEthMsgMaster(1),
                obEthMsgSlave   => intEthMsgSlave (1));
-           
+
       end generate BSA_EN_GEN;
 
       BSA_DISABLE_GEN : if (DISABLE_BSA_G) generate

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
@@ -212,6 +212,8 @@ architecture mapping of AmcCarrierCore is
    signal axilRst : sl;
    signal auxPwrL : sl;
 
+   signal diagnosticBusReg : DiagnosticBusType := DIAGNOSTIC_BUS_INIT_C;
+
 begin
 
    assert (RSSI_ILEAVE_EN_G = false) or (RSSI_ILEAVE_EN_G and (DISABLE_BSA_G = false) and (DISABLE_BLD_G = false))
@@ -234,6 +236,14 @@ begin
 
    stableClk <= fabClk;
    stableRst <= fabRst;
+
+   -- Register to help with making timing
+   process(diagnosticClk)
+   begin
+      if rising_edge(diagnosticClk) then
+         diagnosticBusReg <= diagnosticBus after TPD_G;
+      end if;
+   end process;
 
    --------------------------------
    -- Common Clock and Reset Module
@@ -463,7 +473,7 @@ begin
          -- Diagnostic Interface
          diagnosticClk        => diagnosticClk,
          diagnosticRst        => diagnosticRst,
-         diagnosticBus        => diagnosticBus,
+         diagnosticBus        => diagnosticBusReg,
          -- Waveform interface (axiClk domain)
          waveformClk          => axiClk,
          waveformRst          => axiRst,

--- a/AppTop/rtl/AppMsgOb.vhd
+++ b/AppTop/rtl/AppMsgOb.vhd
@@ -138,8 +138,9 @@ begin
 
    RX_FIFO : entity surf.SynchronizerFifo
       generic map (
-         TPD_G        => TPD_G,
-         DATA_WIDTH_G => DATA_WIDTH_G)
+         TPD_G         => TPD_G,
+         MEMORY_TYPE_G => "block",
+         DATA_WIDTH_G  => DATA_WIDTH_G)
       port map (
          rst    => rst,
          -- Write Ports

--- a/AppTop/rtl/xcku040_mpsln/AppTopJesd.vhd
+++ b/AppTop/rtl/xcku040_mpsln/AppTopJesd.vhd
@@ -245,7 +245,13 @@ begin
    jesdMmcmLocked <= '1'     when((JESD_RX_LANE_G = 0) and (JESD_TX_LANE_G = 0)) else locked;
 
    jesdClk <= jesdClk185;
-   jesdRst <= jesdRst185;
+   U_jesdRst : entity surf.RstPipeline
+      generic map (
+         TPD_G => TPD_G)
+      port map (
+         clk    => jesdClk185,
+         rstIn  => jesdRst185,
+         rstOut => jesdRst);
 
    U_jesdUsrClk : entity surf.ClockManagerUltraScale
       generic map (

--- a/BsaCore/rtl/BsasAccumulator.vhd
+++ b/BsaCore/rtl/BsasAccumulator.vhd
@@ -190,7 +190,7 @@ begin
        MULTSIGNIN                   => '0',
        OPMODE      (8 downto 7)     => "00",
        OPMODE      (6 downto 4)     => "011",  -- Z = C
-       OPMODE      (3 downto 2)     => "00", 
+       OPMODE      (3 downto 2)     => "00",
        OPMODE      (1 downto 0)     => "11",   -- X = A|B
        PCIN                         => (others=>'0'),  -- unused
        RSTA                         => '0',
@@ -253,7 +253,7 @@ begin
        MULTSIGNIN                   => '0',
        OPMODE      (8 downto 7)     => "00",
        OPMODE      (6 downto 4)     => "011",  -- Z = C
-       OPMODE      (3 downto 2)     => "00", 
+       OPMODE      (3 downto 2)     => "00",
        OPMODE      (1 downto 0)     => "11",   -- X = A|B
        PCIN                         => (others=>'0'),  -- unused
        RSTA                         => '0',
@@ -426,7 +426,7 @@ begin
    diagnosticMin <= resize(srlOut(127 downto  96),48,srlOut(127));
    diagnosticMax <= resize(srlOut(159 downto 128),48,srlOut(159));
    resSmp        <= srlOut(191 downto 160);
-     
+
    comb : process (diagnosticSevr, diagnosticFixd, diagnosticExc,
                    resNacc, resSum, resSmp, resVar, ufSum, ofSum, ofVar,
                    acquire, flush, valid, sample, srlOut,
@@ -438,7 +438,7 @@ begin
       v.axisMaster.tValid := '0';
       v.axisMaster.tLast  := '0';
       v.ready             := '0';
-      
+
       case r.state is
         when IDLE_S =>
           if valid = '1' then
@@ -461,7 +461,7 @@ begin
                                                 (r.sumExcepts(0) or ufSum or ofSum or uOr(resNacc(15 downto 13))) &
                                                 srlOut(12 downto 0);
           v.axisMaster.tLast  := '1';
-          
+
           v.clear     := '1';
           v.state     := DATA_S;
 
@@ -510,7 +510,7 @@ begin
    end process comb;
 
    ready  <= rin.ready;
-   
+
    seq : process (clk) is
    begin
       if (rising_edge(clk)) then

--- a/BsaCore/rtl/BsasModule.vhd
+++ b/BsaCore/rtl/BsasModule.vhd
@@ -64,7 +64,7 @@ architecture rtl of BsasModule is
      TKEEP_MODE_C  => EMAC_AXIS_CONFIG_C.TKEEP_MODE_C,
      TUSER_BITS_C  => EMAC_AXIS_CONFIG_C.TUSER_BITS_C,
      TUSER_MODE_C  => EMAC_AXIS_CONFIG_C.TUSER_MODE_C );
-   
+
    signal config : BsasConfigType;
    signal csync  : BsasConfigType;
    signal cv, csyncv : slv(BSAS_CONFIG_BITS_C-1 downto 0);
@@ -72,7 +72,7 @@ architecture rtl of BsasModule is
    constant NCHAN_C : integer := BSA_DIAGNOSTIC_OUTPUTS_C;
 
    type StateType is (IDLE_S, HEADER_S, DATA_S, FORWARD_S, SINK_S);
-   
+
    type RegType is record
       state          : StateType;
       init           : sl;
@@ -141,7 +141,7 @@ architecture rtl of BsasModule is
    signal trigRatesVec   : Slv32Array(2 downto 0);
 
    signal ready : sl;
-   
+
 begin
 
    U_AxiLiteXbar : entity surf.AxiLiteCrossbar
@@ -176,7 +176,7 @@ begin
    config.enable      <= axilWriteRegs(0)(0);
    config.channelMask <= resize(axilWriteRegs(1),NCHAN_C);
    config.channelSevr <= axilWriteRegs(3) & axilWriteRegs(2);
-   
+
    U_Axil_Evr : entity lcls_timing_core.EvrV2ChannelReg
      generic map (
        NCHANNELS_G => 3 )
@@ -189,7 +189,7 @@ begin
        axilReadSlave   => axilReadSlaves  (1),
        channelConfig   => config.channels,
        eventCount      => trigRatesVec );
-       
+
    U_FIFO : entity surf.AxiStreamFifoV2
      generic map ( FIFO_ADDR_WIDTH_G   => 11,
                    FIFO_PAUSE_THRESH_G => 1024,
@@ -237,7 +237,7 @@ begin
 
    cv    <= toSlv(config);
    csync <= toBsasConfigType(csyncv);
-       
+
    -- Signal to latch data for this pulse
    U_Acquire : entity lcls_timing_core.EvrV2EventSelect
      port map (
@@ -285,7 +285,7 @@ begin
    trigRatesVec(0) <= muxSlVectorArray(trigRatesArray,0);
    trigRatesVec(1) <= muxSlVectorArray(trigRatesArray,1);
    trigRatesVec(2) <= muxSlVectorArray(trigRatesArray,2);
-       
+
    comb: process(r, diagnosticRst, diagnosticBus, acquire, rowAdvance, rowReset, csync,
                  accAxisMaster, ready) is
      variable v       : RegType;
@@ -297,7 +297,7 @@ begin
      v := r;
 
      ichan := conv_integer(r.channel);
-     
+
      v.strobe        := diagnosticBus.strobe;
 
      --  Not the usual axi-stream master/slave handshake
@@ -310,11 +310,11 @@ begin
      if ready = '1' then
        v.accumulateEn := '0';
      end if;
-     
+
      start   := '0';
      advance := '0';
      sample  := '0';
-     
+
      --
      --  States:
      --    HEADER_S : write row header before sending old data and
@@ -418,7 +418,7 @@ begin
        v.rowTimestamp := diagnosticBus.timingMessage.timeStamp;
        v.rowPulseId   := diagnosticBus.timingMessage.pulseId;
      end if;
-     
+
      ----------------------------------------------------------------------------------------------
      -- Accumulation stage - shift new diagnostic data through the accumulators
      ----------------------------------------------------------------------------------------------
@@ -468,10 +468,10 @@ begin
            v.diagnosticSevr(i) := '1';
          end if;
        end loop;
-       
+
        v.channel    := (others => '0');
      end if;
-     
+
      if diagnosticRst = '1' then
        v := REG_INIT_C;
      end if;

--- a/BsaCore/rtl/BsasPkg.vhd
+++ b/BsaCore/rtl/BsasPkg.vhd
@@ -43,7 +43,7 @@ package BsasPkg is
 end BsasPkg;
 
 package body BsasPkg is
-  
+
    function toSlv(r : BsasConfigType) return slv is
       variable v : slv(BSAS_CONFIG_BITS_C-1 downto 0) := (others=>'0');
       variable i : integer := 0;
@@ -74,4 +74,4 @@ package body BsasPkg is
 
 end package body;
 
-  
+

--- a/BsaCore/rtl/BsasSampler.vhd
+++ b/BsaCore/rtl/BsasSampler.vhd
@@ -169,7 +169,7 @@ begin
    end process comb;
 
    ready       <= rin.ready;
-   
+
    seq : process (clk) is
    begin
       if (rising_edge(clk)) then

--- a/BsaCore/rtl/BsasWrapper.vhd
+++ b/BsaCore/rtl/BsasWrapper.vhd
@@ -113,14 +113,18 @@ begin
 
    sAxisMasters(NUM_EDEFS_G) <= ibEthMsgMaster;
    ibEthMsgSlave             <= sAxisSlaves(NUM_EDEFS_G);
-   
+
    U_Mux : entity surf.AxiStreamMux
-     generic map ( NUM_SLAVES_G => NUM_EDEFS_G+1 )
-     port map ( axisClk      => axilClk,
-                axisRst      => axilRst,
-                sAxisMasters => sAxisMasters,
-                sAxisSlaves  => sAxisSlaves,
-                mAxisMaster  => obEthMsgMaster,
-                mAxisSlave   => obEthMsgSlave );
+      generic map (
+         TPD_G         => TPD_G,
+         NUM_SLAVES_G  => NUM_EDEFS_G+1,
+         PIPE_STAGES_G => 1) -- Help with making timing
+      port map (
+         axisClk      => axilClk,
+         axisRst      => axilRst,
+         sAxisMasters => sAxisMasters,
+         sAxisSlaves  => sAxisSlaves,
+         mAxisMaster  => obEthMsgMaster,
+         mAxisSlave   => obEthMsgSlave);
 
 end rtl;

--- a/BsaCore/rtl/BsasWrapper.vhd
+++ b/BsaCore/rtl/BsasWrapper.vhd
@@ -81,7 +81,7 @@ architecture rtl of BsasWrapper is
    signal r_in : RegType;
 
    signal dbus : DiagnosticBusType;
-   
+
 begin
 
    U_AxiLiteXbar : entity surf.AxiLiteCrossbar
@@ -166,5 +166,5 @@ begin
        r <= r_in;
      end if;
    end process seq;
-   
+
 end rtl;


### PR DESCRIPTION
### Description
- For AmcCarrierBsa.vhd, terminate unused AXIS slave with AXI_STREAM_SLAVE_FORCE_C
- In AmcCarrierCore.vhd, register the diagnosticBus to help with making timing
- For AppMsgOb.vhd, change the RX_FIFO from LUTRAM to BRAM
- For xcku040_mpsln/AppTopJesd.vhd, using surf.RstPipeline to help with making timing for jesdRst
- For BsasModule.vhd, whitespace removal
- For BsasPkg.vhd, whitespace removal
- For BsasSampler.vhd, whitespace removal
- For BsasWrapper.vhd, register the diagnosticBus to help with making timing and set `surf.AxiStreamMux.PIPE_STAGES_=1`
- For DaqRegItf.vhd, Optimizing for reduce LUTs