### PR TITLE
Alt table order

### DIFF
--- a/AppMps/rtl/AppMpsSelect.vhd
+++ b/AppMps/rtl/AppMpsSelect.vhd
@@ -120,7 +120,7 @@ begin
       beamDest(conv_integer(diagnosticBus.timingMessage.beamRequest(7 downto 4))) := '1';
 
       -- Beam enable decode
-      v.mpsSelect.selectIdle := ite(((beamDest and beamDestInt) /= 0),'0', '1');
+      v.mpsSelect.selectIdle := ite((((beamDest and beamDestInt) /= 0) or (beamDest and altDestInt) /= 0)),'0', '1');
 
       -- Alt table decode
       v.mpsSelect.selectAlt := ite(((beamDest and altDestInt) /= 0),'1','0');

--- a/AppMps/rtl/AppMpsSelect.vhd
+++ b/AppMps/rtl/AppMpsSelect.vhd
@@ -120,7 +120,7 @@ begin
       beamDest(conv_integer(diagnosticBus.timingMessage.beamRequest(7 downto 4))) := '1';
 
       -- Beam enable decode
-      v.mpsSelect.selectIdle := ite((((beamDest and beamDestInt) /= 0) or (beamDest and altDestInt) /= 0)),'0', '1');
+      v.mpsSelect.selectIdle := ite((((beamDest and beamDestInt) /= 0) or ((beamDest and altDestInt) /= 0)),'0', '1');
 
       -- Alt table decode
       v.mpsSelect.selectAlt := ite(((beamDest and altDestInt) /= 0),'1','0');


### PR DESCRIPTION
Jeremy comments: "I think that in this logic, if selectAlt is true, selectIdle will also be true since the alternate destination is not necessarily included within the standard primary destination.  Then the encoder evaluates the standard destination first.

I think we should consider making it so that selectIdle is only true if the received destination does not match with either the standard or alternate user set destinations."
