### PR TITLE
V4.8.3 bsa bsss reallocation

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,37 +1,59 @@
 [flake8]
-exclude = __init__.py
 #############################################################
 # Note: Comamnd to remove white space at the end of lines
 # $ find . -type f -name "*.py" -print0 | xargs -0 sed -i 's/\s*$//g'
 #############################################################
-# E116 unexpected indentation (comment)
-# E128 continuation line under-indented for visual indent
-# E131 continuation line unaligned for hanging indent
-# E201 whitespace after '('
-# E202 whitespace before ')'
-# E203 whitespace before ':'
-# E211 whitespace before '('
-# E221 multiple spaces before operator
-# E222 multiple spaces after operator
-# E225 missing whitespace around operator
-# E226 missing whitespace around arithmetic operator
-# E227 missing whitespace around bitwise or shift operator
-# E228 missing whitespace around modulo operator
-# E231 missing whitespace after ','
-# E241 multiple spaces after ','
-# E251 unexpected spaces around keyword / parameter equals
-# E261 at least two spaces before inline comment
-# E262 inline comment should start with '# '
-# E265 block comment should start with '# '
-# E266 too many leading '#' for block comment
-# E272 multiple spaces before keyword
-# E302 expected 2 blank lines, found 1
-# E303 too many blank lines
-# E305 expected 2 blank lines after class or function definition
-# E306 expected 1 blank line before a nested definition, found 0
-# E501 line too long
-#############################################################
-ignore = E116,E128,E131,\
-         E201,E202,E203,E211,E221,E222,E225,E226,E227,E228,E231,E241,E251,E261,E262,E265,E266,E272,\
-         E302,E303,E305,E306,\
-         E501
+exclude = __init__.py
+extend-ignore =
+   # E116: unexpected indentation (comment)
+   E116,
+   # E128: continuation line under-indented for visual indent
+   E128,
+   # E131: continuation line unaligned for hanging indent
+   E131,
+   # E201: whitespace after '('
+   E201,
+   # E202: whitespace before ')'
+   E202,
+   # E203: whitespace before ':'
+   E203,
+   # E211: whitespace before '('
+   E211,
+   # E221: multiple spaces before operator
+   E221,
+   # E222: multiple spaces after operator
+   E222,
+   # E225: missing whitespace around operator
+   E225,
+   # E226: missing whitespace around arithmetic operator
+   E226,
+   # E227: missing whitespace around bitwise or shift operator
+   E227,
+   # E228: missing whitespace around modulo operator
+   E228,
+   # E231: missing whitespace after ','
+   E231,
+   # E241: multiple spaces after ','
+   E241,
+   # E251: unexpected spaces around keyword / parameter equals
+   E251,
+   # E261: at least two spaces before inline comment
+   E261,
+   # E262: inline comment should start with '# '
+   E262,
+   # E265: block comment should start with '# '
+   E265,
+   # E266: too many leading '#' for block comment
+   E266,
+   # E272: multiple spaces before keyword
+   E272,
+   # E302: expected 2 blank lines, found 1
+   E302,
+   # E303: too many blank lines
+   E303,
+   # E305: expected 2 blank lines after class or function definition
+   E305,
+   # E306: expected 1 blank line before a nested definition, found 0
+   E306,
+   # E501: line too long
+   E501

--- a/AmcCarrierCore/core/AmcCarrierBsa.vhd
+++ b/AmcCarrierCore/core/AmcCarrierBsa.vhd
@@ -350,7 +350,7 @@ begin
                axiWriteSlave    => bsaAxiWriteSlave);
          BsssWrapper : entity amc_carrier_core.BsssWrapper
             generic map (
-               NUM_EDEFS_G => 9)
+               NUM_EDEFS_G => BSA_BUFFERS_C-4)
             port map (
                diagnosticClk   => diagnosticClk,
                diagnosticRst   => diagnosticRst,

--- a/AmcCarrierCore/core/AmcCarrierBsa.vhd
+++ b/AmcCarrierCore/core/AmcCarrierBsa.vhd
@@ -104,11 +104,12 @@ architecture mapping of AmcCarrierBsa is
    constant BSA_BUFFER_AXIL_C : integer := 0;
    constant WAVEFORM_0_AXIL_C : integer := 1;
    constant WAVEFORM_1_AXIL_C : integer := 2;
-   constant BSSS_AXIL_C       : integer := 3;
-   constant BLD_AXIL_C        : integer := 4;
-   constant BSAS_AXIL_C       : integer := 5;
+   constant BSSS0_AXIL_C      : integer := 3;
+   constant BSSS1_AXIL_C      : integer := 4;
+   constant BLD_AXIL_C        : integer := 5;
+   constant BSAS_AXIL_C       : integer := 6;
 
-   constant AXIL_MASTERS_C : integer := 6;
+   constant AXIL_MASTERS_C    : integer := 7;
 
    constant AXIL_CROSSBAR_CONFIG_C : AxiLiteCrossbarMasterConfigArray(AXIL_MASTERS_C-1 downto 0) :=
       genAxiLiteConfig(AXIL_MASTERS_C, BSA_ADDR_C, 20, 16);
@@ -168,8 +169,8 @@ architecture mapping of AmcCarrierBsa is
    signal waveform1AxiReadMaster  : AxiReadMasterType  := AXI_READ_MASTER_INIT_C;
    signal waveform1AxiReadSlave   : AxiReadSlaveType   := AXI_READ_SLAVE_INIT_C;
 
-   signal intEthMsgMaster : AxiStreamMasterArray(1 downto 0) := (others=>AXI_STREAM_MASTER_INIT_C);
-   signal intEthMsgSlave  : AxiStreamSlaveArray (1 downto 0) := (others=>AXI_STREAM_SLAVE_FORCE_C);
+   signal intEthMsgMaster : AxiStreamMasterArray(2 downto 0) := (others=>AXI_STREAM_MASTER_INIT_C);
+   signal intEthMsgSlave  : AxiStreamSlaveArray (2 downto 0) := (others=>AXI_STREAM_SLAVE_FORCE_C);
 
 begin
 
@@ -350,25 +351,49 @@ begin
                axiWriteSlave    => bsaAxiWriteSlave);
          BsssWrapper : entity amc_carrier_core.BsssWrapper
             generic map (
-               NUM_EDEFS_G => BSA_BUFFERS_C-4)
+               NUM_EDEFS_G => ite(BSA_BUFFERS_C>32,28,BSA_BUFFERS_C-4),
+               SVC_START_G => 0,
+               SVC_TYPE_G  => 0 )
             port map (
                diagnosticClk   => diagnosticClk,
                diagnosticRst   => diagnosticRst,
                diagnosticBus   => diagnosticBus,
                axilClk         => axilClk,
                axilRst         => axilRst,
-               axilReadMaster  => locAxilReadMasters (BSSS_AXIL_C),
-               axilReadSlave   => locAxilReadSlaves  (BSSS_AXIL_C),
-               axilWriteMaster => locAxilWriteMasters(BSSS_AXIL_C),
-               axilWriteSlave  => locAxilWriteSlaves (BSSS_AXIL_C),
+               axilReadMaster  => locAxilReadMasters (BSSS0_AXIL_C),
+               axilReadSlave   => locAxilReadSlaves  (BSSS0_AXIL_C),
+               axilWriteMaster => locAxilWriteMasters(BSSS0_AXIL_C),
+               axilWriteSlave  => locAxilWriteSlaves (BSSS0_AXIL_C),
                ibEthMsgMaster  => ibEthMsgMaster,
                ibEthMsgSlave   => ibEthMsgSlave,
                obEthMsgMaster  => intEthMsgMaster(0),
                obEthMsgSlave   => intEthMsgSlave (0));
+         GEN_BSSS1 : if BSA_BUFFERS_C > 32 generate
+           BsssWrapper1 : entity amc_carrier_core.BsssWrapper
+             generic map (
+               NUM_EDEFS_G => BSA_BUFFERS_C-32,
+               SVC_START_G => 28,
+               SVC_TYPE_G  => 1 )
+             port map (
+               diagnosticClk   => diagnosticClk,
+               diagnosticRst   => diagnosticRst,
+               diagnosticBus   => diagnosticBus,
+               axilClk         => axilClk,
+               axilRst         => axilRst,
+               axilReadMaster  => locAxilReadMasters (BSSS1_AXIL_C),
+               axilReadSlave   => locAxilReadSlaves  (BSSS1_AXIL_C),
+               axilWriteMaster => locAxilWriteMasters(BSSS1_AXIL_C),
+               axilWriteSlave  => locAxilWriteSlaves (BSSS1_AXIL_C),
+               ibEthMsgMaster  => intEthMsgMaster(0),
+               ibEthMsgSlave   => intEthMsgSlave (0),
+               obEthMsgMaster  => intEthMsgMaster(1),
+               obEthMsgSlave   => intEthMsgSlave (1));
+         end generate GEN_BSSS1;
+         NOGEN_BSSS1 : if BSA_BUFFERS_C < 33 generate
+           intEthMsgMaster(1) <= intEthMsgMaster(0);
+           intEthMsgSlave (0) <= intEthMsgSlave (1);
+         end generate NOGEN_BSSS1;
          BsasWrapper : entity amc_carrier_core.BsasWrapper
-            generic map  (
-               NUM_EDEFS_G => 4,
-               BASE_ADDR_G => AXIL_CROSSBAR_CONFIG_C(BSAS_AXIL_C).baseAddr)
             port map (
                diagnosticClk   => diagnosticClk,
                diagnosticRst   => diagnosticRst,
@@ -379,20 +404,18 @@ begin
                axilReadSlave   => locAxilReadSlaves  (BSAS_AXIL_C),
                axilWriteMaster => locAxilWriteMasters(BSAS_AXIL_C),
                axilWriteSlave  => locAxilWriteSlaves (BSAS_AXIL_C),
-               ibEthMsgMaster  => intEthMsgMaster(0),
-               ibEthMsgSlave   => intEthMsgSlave (0),
-               obEthMsgMaster  => intEthMsgMaster(1),
-               obEthMsgSlave   => intEthMsgSlave (1));
+               ibEthMsgMaster  => intEthMsgMaster(1),
+               ibEthMsgSlave   => intEthMsgSlave (1),
+               obEthMsgMaster  => intEthMsgMaster(2),
+               obEthMsgSlave   => intEthMsgSlave (2));
 
       end generate BSA_EN_GEN;
 
       BSA_DISABLE_GEN : if (DISABLE_BSA_G) generate
-         locAxilReadSlaves(BSA_BUFFER_AXIL_C)      <= AXI_LITE_READ_SLAVE_EMPTY_OK_C;
-         locAxilWriteSlaves(BSA_BUFFER_AXIL_C)     <= AXI_LITE_WRITE_SLAVE_EMPTY_OK_C;
          bsaAxiWriteMaster                         <= AXI_WRITE_MASTER_INIT_C;
          obBsaMasters(BSA_BSA_STATUS_AXIS_INDEX_C) <= AXI_STREAM_MASTER_INIT_C;
-         intEthMsgMaster(1)                        <= ibEthMsgMaster;
-         ibEthMsgSlave                             <= intEthMsgSlave(1);
+         intEthMsgMaster(2)                        <= ibEthMsgMaster;
+         ibEthMsgSlave                             <= intEthMsgSlave(2);
       end generate BSA_DISABLE_GEN;
 
 --      -----------------------------------------------------------------------------------------------
@@ -489,15 +512,15 @@ begin
             axilReadSlave   => locAxilReadSlaves  (BLD_AXIL_C),
             axilWriteMaster => locAxilWriteMasters(BLD_AXIL_C),
             axilWriteSlave  => locAxilWriteSlaves (BLD_AXIL_C),
-            ibEthMsgMaster  => intEthMsgMaster(1),
-            ibEthMsgSlave   => intEthMsgSlave (1),
+            ibEthMsgMaster  => intEthMsgMaster(2),
+            ibEthMsgSlave   => intEthMsgSlave (2),
             obEthMsgMaster  => obEthMsgMaster,
             obEthMsgSlave   => obEthMsgSlave );
    end generate;
 
    BLD_DISABLE_GEN : if DISABLE_BLD_G generate
-      obEthMsgMaster    <= intEthMsgMaster(1);
-      intEthMsgSlave(1) <= obEthMsgSlave;
+      obEthMsgMaster    <= intEthMsgMaster(2);
+      intEthMsgSlave(2) <= obEthMsgSlave;
    end generate;
 
 end mapping;

--- a/AmcCarrierCore/core/AmcCarrierPkg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierPkg.vhd
@@ -75,7 +75,7 @@ package AmcCarrierPkg is
    -------------------------------------------------------------------------------------------------
    -- BSA configuration
    -------------------------------------------------------------------------------------------------
-   constant BSA_BUFFERS_C            : integer := 64;
+   constant BSA_BUFFERS_C            : integer := 48;
    constant BSA_DIAGNOSTIC_OUTPUTS_C : integer := 31;
    constant BSA_STREAM_BYTE_WIDTH_C  : integer := 8;
    constant BSA_BURST_BYTES_C        : integer := 2048;  -- Bytes in each burst of BSA data

--- a/AmcCarrierCore/yaml/AmcCarrierBsa.yaml
+++ b/AmcCarrierCore/yaml/AmcCarrierBsa.yaml
@@ -32,18 +32,21 @@ AmcCarrierBsa: &AmcCarrierBsa
         offset: 0x00010000
         nelms: 2
         stride: 0x00010000
-    Bsss:
-      <<: *BldAxiStream
+    Bsss0:
+      <<: *BsssWrapper
       at:
         offset: 0x00030000
-        numEdefs: 9
+    Bsss1:
+      <<: *BsssWrapper
+      at:
+        offset: 0x00040000
     Bld:
       <<: *BldAxiStream
       at:
-        offset: 0x00040000
+        offset: 0x00050000
         numEdefs: 4
     Bsas:
       <<: *BsasWrapper
       at:
-        offset: 0x00050000
+        offset: 0x00060000
         numEdefs: 4

--- a/BsaCore/rtl/BldAxiStream.vhd
+++ b/BsaCore/rtl/BldAxiStream.vhd
@@ -109,7 +109,8 @@ architecture rtl of BldAxiStream is
                       TSL_S , TSU_S,
                       PIDL_S, PIDU_S,
                       CHM_S , DELT_S,
-                      SVC_S , CHD_S,
+                      SVC_S , SVC2_S,
+                      CHD_S,
                       SEV_S , END_S , INVALID_S);
 
    type BldStatusType is record
@@ -151,10 +152,11 @@ architecture rtl of BldAxiStream is
         when CHM_S     => s := x"5";
         when DELT_S    => s := x"6";
         when SVC_S     => s := x"7";
-        when CHD_S     => s := x"8";
-        when SEV_S     => s := x"9";
-        when END_S     => s := x"A";
-        when INVALID_S => s := x"B";
+        when SVC2_S    => s := x"8";
+        when CHD_S     => s := x"9";
+        when SEV_S     => s := x"A";
+        when END_S     => s := x"B";
+        when INVALID_S => s := x"F";
       end case;
       assignSlv(i, v, s);
       assignSlv(i, v, r.pulseIdL);
@@ -206,7 +208,7 @@ architecture rtl of BldAxiStream is
       -- data
      strobe        : slv       ( 1 downto 0);
      dbus          : DiagnosticBusType;
-     svcMask       : slv       (31 downto 0);
+     svcMask       : slv       (63 downto 0);
      svcTs         : Slv2Array (NUM_EDEFS_G-1 downto 0);
      svcReady      : slv       (NUM_EDEFS_G-1 downto 0);   -- updated for r.strobe(1)
      channelId     : integer range 0 to BSA_DIAGNOSTIC_OUTPUTS_C;
@@ -455,7 +457,10 @@ begin
          when DELT_S => v.master.tData(31 downto 0) := r.status.delta;
                         v.status.count              := r.status.count-1;
                         v.status.state              := SVC_S;
-         when SVC_S  => v.master.tData(31 downto 0) := r.svcMask;
+         when SVC_S  => v.master.tData(31 downto 0) := r.svcMask(31 downto 0);
+                        v.status.count              := r.status.count-1;
+                        v.status.state              := SVC2_S;
+         when SVC2_S => v.master.tData(31 downto 0) := r.svcMask(63 downto 32);
                         v.status.count              := r.status.count-1;
                         v.channelId                 := 0;
                         v.channelSevr               := (others=>'1');

--- a/BsaCore/rtl/BldAxiStream.vhd
+++ b/BsaCore/rtl/BldAxiStream.vhd
@@ -509,7 +509,7 @@ begin
                             end if;
                           elsif eventSelQ /= 0 then
                             --  Append to the current packet
-                            v.svcMask(eventSelQ'left+SVC_START_G downto SVC_START_G) := eventSelQ;
+                            v.svcMask(eventSelQ'left downto 0) := eventSelQ;
                             v.status.delta := resize(deltaPID,12) & resize(deltaTS,20);
                             v.status.state := DELT_S;
                           else
@@ -537,7 +537,7 @@ begin
                               end if;
                             end loop;
                           end if;
-                          v.svcMask(eventSelQ'left+SVC_START_G downto SVC_START_G) := eventSelQ;
+                          v.svcMask(eventSelQ'left downto 0) := eventSelQ;
                           v.channelMaskL   := csync.channelMask;
                           v.status.state   := TSL_S;
                         end if;

--- a/BsaCore/rtl/BldWrapper.vhd
+++ b/BsaCore/rtl/BldWrapper.vhd
@@ -5,7 +5,7 @@
 -- Author     : Matt Weaver <weaver@slac.stanford.edu>
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-09-25
--- Last update: 2021-11-24
+-- Last update: 2022-11-14
 -- Platform   :
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
@@ -60,7 +60,7 @@ architecture rtl of BldWrapper is
 begin
 
   U_Bsss : entity amc_carrier_core.BldAxiStream
-    generic map ( SVC_START_G  => 24,
+    generic map ( SVC_START_G  => 48,
                   NUM_EDEFS_G  => NUM_EDEFS_G,
                   BATCH_G      => true )
     port map (

--- a/BsaCore/rtl/BldWrapper.vhd
+++ b/BsaCore/rtl/BldWrapper.vhd
@@ -60,8 +60,7 @@ architecture rtl of BldWrapper is
 begin
 
   U_Bsss : entity amc_carrier_core.BldAxiStream
-    generic map ( SVC_START_G  => 0,
-                  SVC_TYPE_G   => 2,
+    generic map ( SVC_TYPE_G   => 2,
                   NUM_EDEFS_G  => NUM_EDEFS_G,
                   BATCH_G      => true )
     port map (

--- a/BsaCore/rtl/BldWrapper.vhd
+++ b/BsaCore/rtl/BldWrapper.vhd
@@ -5,7 +5,7 @@
 -- Author     : Matt Weaver <weaver@slac.stanford.edu>
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-09-25
--- Last update: 2022-11-14
+-- Last update: 2022-12-02
 -- Platform   :
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
@@ -60,7 +60,8 @@ architecture rtl of BldWrapper is
 begin
 
   U_Bsss : entity amc_carrier_core.BldAxiStream
-    generic map ( SVC_START_G  => 48,
+    generic map ( SVC_START_G  => 0,
+                  SVC_TYPE_G   => 2,
                   NUM_EDEFS_G  => NUM_EDEFS_G,
                   BATCH_G      => true )
     port map (

--- a/BsaCore/rtl/BsssWrapper.vhd
+++ b/BsaCore/rtl/BsssWrapper.vhd
@@ -30,6 +30,8 @@ library surf;
 use surf.StdRtlPkg.all;
 use surf.AxiLitePkg.all;
 use surf.AxiStreamPkg.all;
+use surf.EthMacPkg.all;
+use surf.SsiPkg.all;
 
 library amc_carrier_core;
 use amc_carrier_core.AmcCarrierPkg.all;
@@ -398,7 +400,7 @@ begin
      --  Reset svcReady when appropriate ts bits change
      if r.strobe(0) = '1' then
        for i in 0 to NUM_EDEFS_G-1 loop
-         j := conv_integer(csync.tsUpdate);
+         j := conv_integer(tsUpdate);
          if r.svcTs(i) /= r.dbus.timingMessage.timeStamp(j+1 downto j) then
            v.svcReady(i) := '1';
          end if;
@@ -517,7 +519,7 @@ begin
                             v.svcReady     := r.svcReady and not eventSelQ;
                             for i in 0 to NUM_EDEFS_G-1 loop
                               if eventSelQ(i)='1' then
-                                j := conv_integer(csync.tsUpdate);
+                                j := conv_integer(tsUpdate);
                                 v.svcTs(i) := r.dbus.timingMessage.timeStamp(j+1 downto j);
                               end if;
                             end loop;

--- a/BsaCore/rtl/BsssWrapper.vhd
+++ b/BsaCore/rtl/BsssWrapper.vhd
@@ -5,11 +5,13 @@
 -- Author     : Matt Weaver <weaver@slac.stanford.edu>
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2021-11-24
--- Last update: 2021-11-24
+-- Last update: 2022-11-20
 -- Platform   :
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
 -- Description:
+-- Modified version of BldAxiStream to use the BSA acquisition bits from the
+-- timing message.
 -------------------------------------------------------------------------------
 -- This file is part of 'LCLS2 Timing Core'.
 -- It is subject to the license terms in the LICENSE.txt file found in the
@@ -57,27 +59,509 @@ end entity BsssWrapper;
 
 architecture rtl of BsssWrapper is
 
+  constant SVC_START_G : integer := 0;
+  constant BATCH_G     : boolean := false;
+  
 begin
 
-  U_Bsss : entity amc_carrier_core.BldAxiStream
-    generic map ( SVC_START_G  => 0,
-                  NUM_EDEFS_G  => NUM_EDEFS_G,
-                  BATCH_G      => false )
-    port map (
-      -- Diagnostic data interface
-      diagnosticClk   => diagnosticClk,
-      diagnosticRst   => diagnosticRst,
-      diagnosticBus   => diagnosticBus,
-      -- AXI Lite interface
-      axilClk         => axilClk,
-      axilRst         => axilRst,
-      axilReadMaster  => axilReadMaster,
-      axilReadSlave   => axilReadSlave,
-      axilWriteMaster => axilWriteMaster,
-      axilWriteSlave  => axilWriteSlave,
-      -- Timing ETH MSG Interface (axilClk domain)
-      ibEthMsgMaster  => ibEthMsgMaster,
-      ibEthMsgSlave   => ibEthMsgSlave,
-      obEthMsgMaster  => obEthMsgMaster,
-      obEthMsgSlave   => obEthMsgSlave );
+   constant START_COUNT : slv(11 downto 0) := toSlv(960, 12);  -- MTU
+
+   type BldConfigType is record
+      enable      : sl;
+      channelMask : slv (BSA_DIAGNOSTIC_OUTPUTS_C-1 downto 0);
+      packetSize  : slv (11 downto 0);
+   end record;
+
+   constant BLD_CONFIG_INIT_C : BldConfigType := (
+      enable      => '0',
+      channelMask => (others => '0'),
+      packetSize  => START_COUNT );
+
+   constant BLD_CONFIG_BITS_C : integer := BSA_DIAGNOSTIC_OUTPUTS_C + 13;
+
+   function toSlv(r : BldConfigType) return slv is
+      variable v : slv(BLD_CONFIG_BITS_C-1 downto 0) := (others=>'0');
+      variable i,j : integer := 0;
+   begin
+      assignSlv(i, v, r.enable);
+      assignSlv(i, v, r.channelMask);
+      assignSlv(i, v, r.packetSize);
+      return v;
+   end function;
+
+   function toBldConfig(v : slv) return BldConfigType is
+      variable c : BldConfigType;
+      variable i,j : integer := 0;
+   begin
+      assignRecord(i, v, c.enable);
+      assignRecord(i, v, c.channelMask);
+      assignRecord(i, v, c.packetSize);
+      return c;
+   end function;
+
+   type StateType is (IDLE_S,
+                      TSL_S , TSU_S,
+                      PIDL_S, PIDU_S,
+                      CHM_S , DELT_S,
+                      SVC_S , SVC2_S,
+                      CHD_S,
+                      SEV_S , END_S , INVALID_S);
+
+   type BldStatusType is record
+      state      : StateType;
+      vstate     : slv (3 downto 0);
+      pulseIdL   : slv (19 downto 0);
+      timeStampL : slv (31 downto 0);
+      delta      : slv (31 downto 0);
+      count      : slv (11 downto 0);
+      pause      : sl;
+      packets    : slv (19 downto 0);
+     depth       : slv       ( 3 downto 0);
+   end record;
+
+   constant BLD_STATUS_INIT_C : BldStatusType := (
+      state      => IDLE_S,
+      vstate     => (others => '0'),
+      pulseIdL   => (others => '0'),
+      timeStampL => (others => '0'),
+      delta      => (others => '0'),
+      count      => START_COUNT,
+      pause      => '1',
+      packets    => (others => '0'),
+      depth       => (others=>'0') );
+
+   constant BLD_STATUS_BITS_C : integer := 125;
+
+   function toSlv(r : BldStatusType) return slv is
+      variable v : slv(BLD_STATUS_BITS_C-1 downto 0) := (others=>'0');
+      variable i : integer := 0;
+      variable s : slv(3 downto 0);
+   begin
+      case r.state is
+         when IDLE_S    => s := x"0";
+        when TSL_S     => s := x"1";
+        when TSU_S     => s := x"2";
+        when PIDL_S    => s := x"3";
+        when PIDU_S    => s := x"4";
+        when CHM_S     => s := x"5";
+        when DELT_S    => s := x"6";
+        when SVC_S     => s := x"7";
+        when SVC2_S    => s := x"8";
+        when CHD_S     => s := x"9";
+        when SEV_S     => s := x"A";
+        when END_S     => s := x"B";
+        when INVALID_S => s := x"F";
+      end case;
+      assignSlv(i, v, s);
+      assignSlv(i, v, r.pulseIdL);
+      assignSlv(i, v, r.timeStampL);
+      assignSlv(i, v, r.delta);
+      assignSlv(i, v, r.count);
+      assignSlv(i, v, r.pause);
+      assignSlv(i, v, r.packets);
+      assignSlv(i, v, r.depth);
+      return v;
+   end function;
+
+   function toBldStatus(v : slv) return BldStatusType is
+      variable c : BldStatusType;
+      variable i : integer := 0;
+   begin
+      assignRecord(i, v, c.vstate);
+      assignRecord(i, v, c.pulseIdL);
+      assignRecord(i, v, c.timeStampL);
+      assignRecord(i, v, c.delta);
+      assignRecord(i, v, c.count);
+      assignRecord(i, v, c.pause);
+      assignRecord(i, v, c.packets);
+      assignRecord(i, v, c.depth);
+      return c;
+   end function;
+
+   type AxilRegType is record
+      config      : BldConfigType;
+      axilWriteS  : AxiLiteWriteSlaveType;
+      axilReadS   : AxiLiteReadSlaveType;
+   end record;
+
+   constant AXIL_REG_INIT_C : AxilRegType := (
+      config      => BLD_CONFIG_INIT_C,
+      axilWriteS  => AXI_LITE_WRITE_SLAVE_INIT_C,
+      axilReadS   => AXI_LITE_READ_SLAVE_INIT_C );
+
+   signal c     : AxilRegType := AXIL_REG_INIT_C;
+   signal cin   : AxilRegType;
+
+   signal csync : BldConfigType;
+   signal cv, csyncv : slv(BLD_CONFIG_BITS_C-1 downto 0);
+
+   signal ssync : BldStatusType;
+   signal sv, ssyncv : slv(BLD_STATUS_BITS_C-1 downto 0);
+
+   type RegType is record
+      -- data
+     strobe        : slv       ( 1 downto 0);
+     dbus          : DiagnosticBusType;
+     svcMask       : slv       (63 downto 0);
+     svcTs         : Slv2Array (NUM_EDEFS_G-1 downto 0);
+     svcReady      : slv       (NUM_EDEFS_G-1 downto 0);   -- updated for r.strobe(1)
+     channelId     : integer range 0 to BSA_DIAGNOSTIC_OUTPUTS_C;
+     channelMaskL  : slv       (BSA_DIAGNOSTIC_OUTPUTS_C-1 downto 0);
+     channelSevr   : slv       (2*BSA_DIAGNOSTIC_OUTPUTS_C-1 downto 0);
+     status        : BldStatusType;
+     master        : AxiStreamMasterType;
+   end record;
+   constant REG_INIT_C : RegType := (
+      strobe        => (others=>'0'),
+      dbus          => DIAGNOSTIC_BUS_INIT_C,
+      svcMask       => (others=>'0'),
+      svcTs         => (others=>"00"),
+      svcReady      => (others=>'1'),
+      channelId     => 0,
+      channelMaskL  => (others=>'0'),
+      channelSevr   => (others=>'1'),
+      status        => BLD_STATUS_INIT_C,
+      master        => AXI_STREAM_MASTER_INIT_C );
+
+   signal r    : RegType := REG_INIT_C;
+   signal rin  : RegType;
+
+   signal intSlave    : AxiStreamSlaveType;
+   signal intAxisCtrl : AxiStreamCtrlType;
+
+   constant axiStreamConfig : AxiStreamConfigType := (
+      TSTRB_EN_C    => false,
+      TDATA_BYTES_C => 4,
+      TDEST_BITS_C  => 8,
+      TID_BITS_C    => 0,
+      TKEEP_MODE_C  => TKEEP_COMP_C,
+      TUSER_BITS_C  => 4,
+      TUSER_MODE_C  => TUSER_FIRST_LAST_C);
+
+   signal sAxisMasters : AxiStreamMasterArray(1 downto 0);
+   signal sAxisSlaves  : AxiStreamSlaveArray(1 downto 0);
+
+   signal eventStrobe  : sl;
+   signal eventSel     : slv(63 downto 0);
+   signal eventSel0Q   : sl;
+
+   signal diagnClkFreq    : slv(31 downto 0);
+   signal diagnStrobeRate : slv(31 downto 0);
+   signal eventSel0Rate   : slv(31 downto 0);
+
+   constant tsUpdate : slv(4 downto 0) := toSlv(27,5);
+   
+begin
+
+   U_DIAGNCLKFREQ : entity surf.SyncClockFreq
+     generic map ( REF_CLK_FREQ_G    => 156.25E+6,
+                   CLK_LOWER_LIMIT_G => 180.0E+6,
+                   CLK_UPPER_LIMIT_G => 220.0E+6 )
+     port map ( freqOut    => diagnClkFreq,
+                clkIn      => diagnosticClk,
+                locClk     => axilClk,
+                refClk     => axilClk );
+
+   U_DIAGNSTRRATE : entity surf.SyncTrigRate
+     generic map ( COMMON_CLK_G      => false,
+                   REF_CLK_FREQ_G    => 156.25E+6 )
+     port map ( trigIn     => diagnosticBus.strobe,
+                trigRateOut=> diagnStrobeRate,
+                locClk     => diagnosticClk,
+                refClk     => axilClk );
+
+   eventSel0Q <= eventSel(0) and eventStrobe;
+   U_EVENTSELRATE : entity surf.SyncTrigRate
+     generic map ( COMMON_CLK_G      => false,
+                   REF_CLK_FREQ_G    => 156.25E+6 )
+     port map ( trigIn     => eventSel0Q,
+                trigRateOut=> eventSel0Rate,
+                locClk     => diagnosticClk,
+                refClk     => axilClk );
+
+   axilReadSlave  <= cin.axilReadS;
+   axilWriteSlave <= cin.axilWriteS;
+
+   sAxisMasters(0) <= ibEthMsgMaster;
+   ibEthMsgSlave   <= sAxisSlaves(0);
+
+   U_FIFO : entity surf.AxiStreamFifoV2
+     generic map ( FIFO_ADDR_WIDTH_G   => 11,
+                   FIFO_PAUSE_THRESH_G => 1900,
+                   VALID_THOLD_G       => 0,   -- only when a full frame is ready
+                   SLAVE_AXI_CONFIG_G  => axiStreamConfig,
+                   MASTER_AXI_CONFIG_G => EMAC_AXIS_CONFIG_C )
+     port map ( sAxisClk     => diagnosticClk,
+                sAxisRst     => diagnosticRst,
+                sAxisMaster  => r.master,
+                sAxisSlave   => intSlave,
+                sAxisCtrl    => intAxisCtrl,
+                mAxisClk     => axilClk,
+                mAxisRst     => axilRst,
+                mAxisMaster  => sAxisMasters(1),
+                mAxisSlave   => sAxisSlaves (1) );
+
+   reg_comb: process(c, axilRst, ssync, axilReadMaster, axilWriteMaster,
+                     diagnClkFreq, diagnStrobeRate, eventSel0Rate ) is
+     variable v   : AxilRegType;
+     variable ep  : AxiLiteEndPointType;
+   begin
+     v := c;
+
+     -----------------------------
+     -- Register access
+     -----------------------------
+
+     -- Start transaction block
+     axiSlaveWaitTxn(ep, axilWriteMaster, axilReadMaster, v.axilWriteS, v.axilReadS);
+
+     axiSlaveRegister(ep, x"000", 0, v.config.packetSize);
+     axiSlaveRegister(ep, x"000",31, v.config.enable);
+     axiSlaveRegister(ep, x"004", 0, v.config.channelMask);
+     axiSlaveRegisterR(ep, x"010", 0, ssync.count);
+     axiSlaveRegisterR(ep, x"010",16, ssync.vstate);
+     axiSlaveRegisterR(ep, x"014", 0, ssync.pulseIdL);
+     axiSlaveRegisterR(ep, x"018", 0, ssync.timeStampL);
+     axiSlaveRegisterR(ep, x"01C", 0, ssync.delta);
+     axiSlaveRegisterR(ep, x"020", 0, ssync.packets);
+     axiSlaveRegisterR(ep, x"020",31, ssync.pause);
+     axiSlaveRegisterR(ep, x"024", 0, ssync.depth);
+     axiSlaveRegisterR(ep, x"028", 0, diagnClkFreq);
+     axiSlaveRegisterR(ep, x"02C", 0, diagnStrobeRate);
+     axiSlaveRegisterR(ep, x"030", 0, eventSel0Rate);
+
+     axiSlaveDefault (ep, v.axilWriteS, v.axilReadS);
+
+     if axilRst = '1' then
+       v := AXIL_REG_INIT_C;
+     end if;
+
+     cin <= v;
+   end process;
+
+   reg_seq: process(axilClk) is
+   begin
+     if rising_edge(axilClk) then
+       c <= cin;
+     end if;
+   end process;
+
+   cv    <= toSlv      (c.config);
+   csync <= toBldConfig(csyncv);
+
+   U_CSYNC : entity surf.SynchronizerVector
+     generic map ( WIDTH_G => BLD_CONFIG_BITS_C )
+     port map ( clk     => diagnosticClk,
+                dataIn  => cv,
+                dataOut => csyncv );
+
+   sv    <= toSlv      (r.status);
+   ssync <= toBldStatus(ssyncv);
+
+   U_SSYNC : entity surf.SynchronizerVector
+     generic map ( WIDTH_G => BLD_STATUS_BITS_C )
+     port map ( clk     => axilClk,
+                dataIn  => sv,
+                dataOut => ssyncv );
+
+   eventSel    <= r.dbus.timingMessage.bsaActive and
+                  r.dbus.timingMessage.bsaAvgDone and not
+                  r.dbus.timingMessage.bsaInit;
+   eventStrobe <= r.strobe(0);
+
+   comb: process(r, csync,
+                 diagnosticRst, diagnosticBus, eventSel, eventStrobe,
+                 intSlave, intAxisCtrl ) is
+     variable v         : RegType;
+     variable deltaPID  : slv(19 downto 0);
+     variable deltaTS   : slv(31 downto 0);
+     variable eventSelQ : slv(eventSel'range);
+     variable j         : integer;
+   begin
+     if BATCH_G then
+       eventSelQ := eventSel;
+     else
+       eventSelQ := eventSel and r.svcReady;
+     end if;
+
+     -- Dont start a new frame if not enough space in the fifo
+     if intAxisCtrl.pause = '1' then
+       eventSelQ := (others=>'0');
+     end if;
+
+     v := r;
+
+     if diagnosticBus.strobe = '1' then
+       v.dbus := diagnosticBus;
+     end if;
+
+     v.strobe := r.strobe(r.strobe'left-1 downto 0) & diagnosticBus.strobe;
+
+     --  Reset svcReady when appropriate ts bits change
+     if r.strobe(0) = '1' then
+       for i in 0 to NUM_EDEFS_G-1 loop
+         j := conv_integer(csync.tsUpdate);
+         if r.svcTs(i) /= r.dbus.timingMessage.timeStamp(j+1 downto j) then
+           v.svcReady(i) := '1';
+         end if;
+       end loop;
+     end if;
+
+     if intSlave.tReady = '1' then
+       v.master.tValid := '0';
+     end if;
+
+     if v.master.tValid = '0' then
+       ssiSetUserSof ( axiStreamConfig, v.master, '0' );
+       ssiSetUserEofe( axiStreamConfig, v.master, '0' );
+
+       v.master.tValid := '1';
+       v.master.tLast  := '0';
+
+       case r.status.state is
+         -- Full event header
+         when TSL_S  => v.status.count              := csync.packetSize;
+                        v.master.tData(31 downto 0) := r.dbus.timingMessage.timeStamp(31 downto 0);
+                        v.status.timeStampL         := r.dbus.timingMessage.timeStamp(31 downto 0);
+                        v.status.state              := TSU_S;
+                        ssiSetUserSof( axiStreamConfig, v.master, '1' );
+         when TSU_S  => v.master.tData(31 downto 0) := r.dbus.timingMessage.timeStamp(63 downto 32);
+                        v.status.count              := r.status.count-1;
+                        v.status.state              := PIDL_S;
+         when PIDL_S => v.master.tData(31 downto 0) := r.dbus.timingMessage.pulseId  (31 downto 0);
+                        v.status.count              := r.status.count-1;
+                        v.status.pulseIdL           := r.dbus.timingMessage.pulseId  (19 downto 0);
+                        v.status.state              := PIDU_S;
+         when PIDU_S => v.master.tData(31 downto 0) := r.dbus.timingMessage.pulseId   (63 downto 32);
+                        v.status.count              := r.status.count-1;
+                        v.status.state              := CHM_S;
+         when CHM_S  => v.master.tData(31 downto 0) := resize(r.channelMaskL,32);
+                        v.status.count              := r.status.count-1;
+                        v.status.state              := SVC_S;
+         -- Reduced event header
+         when DELT_S => v.master.tData(31 downto 0) := r.status.delta;
+                        v.status.count              := r.status.count-1;
+                        v.status.state              := SVC_S;
+         when SVC_S  => v.master.tData(31 downto 0) := r.svcMask(31 downto 0);
+                        v.status.count              := r.status.count-1;
+                        v.status.state              := SVC2_S;
+         when SVC2_S => v.master.tData(31 downto 0) := r.svcMask(63 downto 32);
+                        v.status.count              := r.status.count-1;
+                        v.channelId                 := 0;
+                        v.channelSevr               := (others=>'1');
+                        v.status.state              := CHD_S;
+         -- Channel data
+         when CHD_S  => if r.channelId < BSA_DIAGNOSTIC_OUTPUTS_C then
+                          --  Only include channels in header's mask
+                          v.master.tValid := '0';
+                          v.channelId     := r.channelId + 1;
+                          v.channelSevr   := r.dbus.sevr(r.channelId)(1) &
+                                             r.dbus.sevr(r.channelId)(0) &
+                                             r.channelSevr(r.channelSevr'left downto 2);
+                          if r.channelMaskL(r.channelId) = '1' then
+                            v.master.tValid := '1';
+                            v.master.tData(31 downto 0)  := r.dbus.data(r.channelId);
+                            v.status.count               := r.status.count-1;
+                          end if;
+                        else
+                          v.master.tValid := '0';
+                          v.status.state  := SEV_S;
+                        end if;
+         when SEV_S  => v.master.tData(31 downto 0) := resize(r.channelSevr,32);
+                        v.status.count              := r.status.count-1;
+                        v.status.state              := END_S;
+         -- Event trailer: hold until next strobe; decide to append or open a new packet
+         when END_S  => if not BATCH_G then
+                          v.master.tData(31 downto 0) := resize(r.channelSevr(r.channelSevr'left downto 32),32);
+                          v.master.tLast              := '1';
+                          v.status.packets            := r.status.packets + 1;
+                          v.status.state              := IDLE_S;
+                        elsif eventStrobe = '1' then
+                          v.master.tData(31 downto 0) := resize(r.channelSevr(r.channelSevr'left downto 32),32);
+                          --
+                          -- Check the duration and size of this frame
+                          --
+                          v.status.count  := r.status.count-1;
+                          deltaPID := r.dbus.timingMessage.pulseId  (19 downto 0) - r.status.pulseIdL;
+                          deltaTS  := r.dbus.timingMessage.timeStamp(31 downto 0) - r.status.timeStampL;
+                          if (deltaTS (31 downto 20)/=0 or
+                              r.status.count(r.status.count'left)='1') then
+                            --  Close the packet and start a new one
+                            v.master.tLast := '1';
+                            v.status.packets := r.status.packets + 1;
+                            if (eventSelQ = 0) then
+                              v.status.state := IDLE_S;
+                            else
+                              v.status.state  := TSL_S;
+                            end if;
+                          elsif eventSelQ /= 0 then
+                            --  Append to the current packet
+                            v.svcMask(eventSelQ'left+SVC_START_G downto SVC_START_G) := eventSelQ;
+                            v.status.delta := resize(deltaPID,12) & resize(deltaTS,20);
+                            v.status.state := DELT_S;
+                          else
+                            --  Keep waiting
+                            v.status.count  := r.status.count;
+                            v.master.tValid := '0';
+                          end if;
+                        else
+                          v.master.tValid := '0';
+                        end if;
+         when INVALID_S => v.master.tLast := '1';
+                           ssiSetUserEofe( axiStreamConfig, v.master, '1' );
+                           v.status.state := IDLE_S;
+         when IDLE_S => v.master.tValid := '0';
+                        if ( csync.enable = '1' and
+                             eventStrobe  = '1' and
+                             eventSelQ   /= 0 ) then
+                          if not BATCH_G then
+                            --  latch the EDEFs and start the timer
+                            v.svcReady     := r.svcReady and not eventSelQ;
+                            for i in 0 to NUM_EDEFS_G-1 loop
+                              if eventSelQ(i)='1' then
+                                j := conv_integer(csync.tsUpdate);
+                                v.svcTs(i) := r.dbus.timingMessage.timeStamp(j+1 downto j);
+                              end if;
+                            end loop;
+                          end if;
+                          v.svcMask(eventSelQ'left+SVC_START_G downto SVC_START_G) := eventSelQ;
+                          v.channelMaskL   := csync.channelMask;
+                          v.status.state   := TSL_S;
+                        end if;
+       end case;
+
+       --  Close prematurely if disable requested
+       if ( csync.enable = '0' and v.status.state /= IDLE_S ) then
+         v.status.state := INVALID_S;
+       end if;
+
+
+     --  Output FIFO refused to acknowledge data
+     elsif (v.status.state /= IDLE_S) then
+       v.status.state := INVALID_S;
+     end if;
+
+     if diagnosticRst = '1' then
+       v := REG_INIT_C;
+     end if;
+
+     rin <= v;
+   end process;
+
+   seq: process(diagnosticClk) is
+   begin
+     if rising_edge(diagnosticClk) then
+       r <= rin;
+     end if;
+   end process;
+
+   U_Mux : entity surf.AxiStreamMux
+     generic map ( NUM_SLAVES_G => 2 )
+     port map ( axisClk      => axilClk,
+                axisRst      => axilRst,
+                sAxisMasters => sAxisMasters,
+                sAxisSlaves  => sAxisSlaves,
+                mAxisMaster  => obEthMsgMaster,
+                mAxisSlave   => obEthMsgSlave );
+
 end rtl;

--- a/BsaCore/rtl/BsssWrapper.vhd
+++ b/BsaCore/rtl/BsssWrapper.vhd
@@ -242,7 +242,7 @@ architecture rtl of BsssWrapper is
    signal sAxisSlaves  : AxiStreamSlaveArray(1 downto 0);
 
    signal eventStrobe  : sl;
-   signal eventSel     : slv(63 downto 0);
+   signal eventSel     : slv(NUM_EDEFS_G-1 downto 0);
    signal eventSel0Q   : sl;
 
    signal diagnClkFreq    : slv(31 downto 0);
@@ -364,9 +364,9 @@ begin
                 dataIn  => sv,
                 dataOut => ssyncv );
 
-   eventSel    <= r.dbus.timingMessage.bsaActive and
-                  r.dbus.timingMessage.bsaAvgDone and not
-                  r.dbus.timingMessage.bsaInit;
+   eventSel    <= (r.dbus.timingMessage.bsaActive and
+                   r.dbus.timingMessage.bsaAvgDone and not
+                   r.dbus.timingMessage.bsaInit)(eventSel'range);
    eventStrobe <= r.strobe(0);
 
    comb: process(r, csync,

--- a/BsaCore/rtl/BsssWrapper.vhd
+++ b/BsaCore/rtl/BsssWrapper.vhd
@@ -242,7 +242,7 @@ architecture rtl of BsssWrapper is
    signal sAxisSlaves  : AxiStreamSlaveArray(1 downto 0);
 
    signal eventStrobe  : sl;
-   signal eventSel     : slv(NUM_EDEFS_G-1 downto 0);
+   signal eventSel     : slv(63 downto 0);
    signal eventSel0Q   : sl;
 
    signal diagnClkFreq    : slv(31 downto 0);
@@ -364,9 +364,9 @@ begin
                 dataIn  => sv,
                 dataOut => ssyncv );
 
-   eventSel    <= (r.dbus.timingMessage.bsaActive and
-                   r.dbus.timingMessage.bsaAvgDone and not
-                   r.dbus.timingMessage.bsaInit)(eventSel'range);
+   eventSel    <= r.dbus.timingMessage.bsaActive and
+                  r.dbus.timingMessage.bsaAvgDone and not
+                  r.dbus.timingMessage.bsaInit;
    eventStrobe <= r.strobe(0);
 
    comb: process(r, csync,
@@ -375,13 +375,13 @@ begin
      variable v         : RegType;
      variable deltaPID  : slv(19 downto 0);
      variable deltaTS   : slv(31 downto 0);
-     variable eventSelQ : slv(eventSel'range);
+     variable eventSelQ : slv(NUM_EDEFS_G-1 downto 0);
      variable j         : integer;
    begin
      if BATCH_G then
-       eventSelQ := eventSel;
+       eventSelQ := eventSel(eventSelQ'range);
      else
-       eventSelQ := eventSel and r.svcReady;
+       eventSelQ := eventSel(eventSelQ'range) and r.svcReady;
      end if;
 
      -- Dont start a new frame if not enough space in the fifo

--- a/BsaCore/rtl/BsssWrapper.vhd
+++ b/BsaCore/rtl/BsssWrapper.vhd
@@ -59,11 +59,9 @@ end entity BsssWrapper;
 
 architecture rtl of BsssWrapper is
 
-  constant SVC_START_G : integer := 0;
-  constant BATCH_G     : boolean := false;
+   constant SVC_START_G : integer := 0;
+   constant BATCH_G     : boolean := false;
   
-begin
-
    constant START_COUNT : slv(11 downto 0) := toSlv(960, 12);  -- MTU
 
    type BldConfigType is record

--- a/BsaCore/yaml/BsssWrapper.yaml
+++ b/BsaCore/yaml/BsssWrapper.yaml
@@ -1,0 +1,236 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+#schemaversion 3.0.0
+#once BsssAxiStream.yaml
+
+BsssAxiStream: &BsssAxiStream
+  name: BsssAxiStream
+  description: Beam line data service
+  size: 0x8000
+  class: MMIODev
+  configPrio: 1
+  metadata:
+    numEdefs: &numEdefs 16
+  ########
+  children:
+  ########
+    #########################################################
+    packetSize:
+      class: IntField
+      at:
+        offset: 0x0
+      sizeBits: 12
+      mode: RW
+      description: "Maximum size of packets in 32b words"
+    #########################################################
+    enable:
+      class: IntField
+      at:
+        offset: 0x3
+      sizeBits: 1
+      lsBit: 7
+      mode: RW
+      description: "Enable packets"
+    #########################################################
+    channelMask:
+      class: IntField
+      at:
+        offset: 0x4
+      sizeBits: 31
+      mode: RW
+      description: "Mask of enabled channels"
+    #########################################################
+    EdefRateLimit:
+      at:
+        offset: 0x8
+      class: IntField
+      name: RateLimit
+      sizeBits: 4
+      lsBit: 0
+      mode: RW
+      enums:
+          class: Enum
+          value: 0
+        - name: INVALID_0
+          class: Enum
+          value: 1
+        - name: INVALID_1
+          class: Enum
+          value: 2
+        - name: Limit_1p9_kHz
+          class: Enum
+          value: 3
+        - name: Limit_950_Hz
+          class: Enum
+          value: 4
+        - name: Limit_476_Hz
+          class: Enum
+          value: 5
+        - name: Limit_238_Hz
+          class: Enum
+          value: 6
+        - name: Limit_119_Hz
+          class: Enum
+          value: 7
+        - name: Limit_59_Hz
+          class: Enum
+          value: 8
+        - name: Limit_29_Hz
+          class: Enum
+          value: 9
+        - name: Limit_14_Hz
+          class: Enum
+          value: 10
+        - name: Limit_7_Hz
+          class: Enum
+          value: 11
+        - name: Limit_3p7_Hz
+          class: Enum
+          value: 12
+        - name: Limit_1p8_Hz
+          class: Enum
+          value: 13
+        - name: Limit_0p9_Hz
+          class: Enum
+          value: 14
+        - name: Limit_0p5_Hz
+          class: Enum
+          value: 15
+      description: Rate Limit
+    #########################################################
+    currPacketSize:
+      class: IntField
+      at:
+        offset: 0x10
+      sizeBits: 12
+      mode: RO
+      description: "Current size of packet in 32b words"
+    #########################################################
+    currPacketState:
+      class: IntField
+      at:
+        offset: 0x12
+      sizeBits: 4
+      mode: RO
+      enums:
+        - name: Idle
+          class: Enum
+          value: 0
+        - name: TSL
+          class: Enum
+          value: 1
+        - name: TSU
+          class: Enum
+          value: 2
+        - name: PIDL
+          class: Enum
+          value: 3
+        - name: PIDU
+          class: Enum
+          value: 4
+        - name: CHM
+          class: Enum
+          value: 5
+        - name: DELT
+          class: Enum
+          value: 6
+        - name: SVC
+          class: Enum
+          value: 7
+        - name: CHD
+          class: Enum
+          value: 8
+        - name: END
+          class: Enum
+          value: 9
+        - name: INVALID_10
+          class: Enum
+          value: 10
+        - name: INVALID_11
+          class: Enum
+          value: 11
+        - name: INVALID_12
+          class: Enum
+          value: 12
+        - name: INVALID_13
+          class: Enum
+          value: 13
+        - name: INVALID_14
+          class: Enum
+          value: 14
+        - name: INVALID_15
+          class: Enum
+          value: 15
+      description: "Current packet fill state"
+    #########################################################
+    currPulseIdL:
+      class: IntField
+      at:
+        offset: 0x14
+      sizeBits: 32
+      mode: RO
+      description: "Current packet pulseID lower word"
+    #########################################################
+    currTimeStampL:
+      class: IntField
+      at:
+        offset: 0x18
+      sizeBits: 32
+      mode: RO
+      description: "Current packet timestamp lower word"
+    #########################################################
+    currDelta:
+      class: IntField
+      at:
+        offset: 0x1C
+      sizeBits: 32
+      mode: RO
+      description: "Current compressed timestamp/pulseID"
+    #########################################################
+    packetCount:
+      class: IntField
+      at:
+        offset: 0x20
+      sizeBits: 20
+      mode: RO
+      description: "Packet count"
+    #########################################################
+    paused:
+      class: IntField
+      at:
+        offset: 0x23
+      sizeBits: 1
+      lsBit: 7
+      mode: RO
+      description: "Stream paused"
+    #########################################################
+    diagnClockRate:
+      class: IntField
+      at:
+        offset: 0x28
+      sizeBits: 32
+      mode: RO
+      description: "Diagn clock rate"
+    #########################################################
+    diagnStrobeRate:
+      class: IntField
+      at:
+        offset: 0x2c
+      sizeBits: 32
+      mode: RO
+      description: "Diagn strobe rate"
+    #########################################################
+    eventSel0Rate:
+      class: IntField
+      at:
+        offset: 0x30
+      sizeBits: 32
+      mode: RO
+      description: "Event select0 rate"

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -10,7 +10,7 @@ if { [VersionCheck 2018.3 ] < 0 } {
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
    if { [SubmoduleCheck {lcls-timing-core} {3.6.5}  "mustBeExact" ] < 0 } {exit -1}
    if { [SubmoduleCheck {ruckus}           {4.3.1}  "mustBeExact" ] < 0 } {exit -1}
-   if { [SubmoduleCheck {surf}             {2.30.1} "mustBeExact" ] < 0 } {exit -1}
+   if { [SubmoduleCheck {surf}             {2.32.0} "mustBeExact" ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"
    puts "OVERRIDE_SUBMODULE_LOCKS != 0"


### PR DESCRIPTION
### Description
- Expands BSSS coverage to all BSA buffers except the top 4 (MPS fault history).  Reduces BSA buffer allocation from 64 to 48.
- [flake8 Version 6 fixes](https://github.com/slaclab/amc-carrier-core/pull/385/commits/2e02cb9a628d775b739746d776fe10c7678466f4)