### PR TITLE
V4.9.0 bsafixes

### DIFF
--- a/AmcCarrierCore/core/AmcCarrierBsa.vhd
+++ b/AmcCarrierCore/core/AmcCarrierBsa.vhd
@@ -394,6 +394,9 @@ begin
            intEthMsgSlave (0) <= intEthMsgSlave (1);
          end generate NOGEN_BSSS1;
          BsasWrapper : entity amc_carrier_core.BsasWrapper
+            generic map (
+               NUM_EDEFS_G => 4,
+               BASE_ADDR_G => AXIL_CROSSBAR_CONFIG_C(BSAS_AXIL_C).baseAddr )
             port map (
                diagnosticClk   => diagnosticClk,
                diagnosticRst   => diagnosticRst,

--- a/AmcCarrierCore/core/AmcCarrierBsi.vhd
+++ b/AmcCarrierCore/core/AmcCarrierBsi.vhd
@@ -106,6 +106,7 @@ architecture rtl of AmcCarrierBsi is
       crateId        : slv(15 downto 0);
       macAddress     : Slv48Array(BSI_MAC_SIZE_C-1 downto 0);
       localIp        : slv(31 downto 0);
+      rst            : slv(2 downto 0);
       axilReadSlave  : AxiLiteReadSlaveType;
       axilWriteSlave : AxiLiteWriteSlaveType;
    end record;
@@ -123,6 +124,7 @@ architecture rtl of AmcCarrierBsi is
       crateId        => x"0000",
       macAddress     => (others => (others => '0')),
       localIp        => x"0000000A",
+      rst            => (others='0'),
       axilReadSlave  => AXI_LITE_READ_SLAVE_INIT_C,
       axilWriteSlave => AXI_LITE_WRITE_SLAVE_INIT_C);
 
@@ -184,7 +186,7 @@ begin
          ENDIANNESS_G         => 1)     -- 0=LE, 1=BE
       port map (
          clk    => axilClk,
-         sRst   => axilRst,
+         sRst   => r.rst(0),
          aRst   => '0',
          addr   => i2cBramAddr(0),
          wrEn   => i2cBramWr(0),
@@ -209,7 +211,7 @@ begin
          ENDIANNESS_G         => 1)     -- 0=LE, 1=BE
       port map (
          clk    => axilClk,
-         sRst   => axilRst,
+         sRst   => r.rst(0),
          aRst   => '0',
          addr   => i2cBramAddr(1),
          wrEn   => i2cBramWr(1),
@@ -451,6 +453,8 @@ begin
       if (axilRst = '1') then
          v := REG_INIT_C;
       end if;
+
+      v.rst := axilRst & r.rst(r.rst'left downto 1);
 
       -- Register the variable for next clock cycle
       rin <= v;

--- a/AmcCarrierCore/core/AmcCarrierBsi.vhd
+++ b/AmcCarrierCore/core/AmcCarrierBsi.vhd
@@ -124,7 +124,7 @@ architecture rtl of AmcCarrierBsi is
       crateId        => x"0000",
       macAddress     => (others => (others => '0')),
       localIp        => x"0000000A",
-      rst            => (others='0'),
+      rst            => (others=>'0'),
       axilReadSlave  => AXI_LITE_READ_SLAVE_INIT_C,
       axilWriteSlave => AXI_LITE_WRITE_SLAVE_INIT_C);
 

--- a/AmcCarrierCore/yaml/AmcCarrierBsa.yaml
+++ b/AmcCarrierCore/yaml/AmcCarrierBsa.yaml
@@ -13,6 +13,7 @@
 #include BsaWaveformEngine.yaml
 #include BldAxiStream.yaml
 #include BsasWrapper.yaml
+#include BsssWrapper.yaml
 
 AmcCarrierBsa: &AmcCarrierBsa
   name: AmcCarrierBsa

--- a/BsaCore/rtl/BsaBufferControl.vhd
+++ b/BsaCore/rtl/BsaBufferControl.vhd
@@ -427,6 +427,7 @@ begin
          BUFFERS_G            => BSA_BUFFERS_G,
          BURST_SIZE_BYTES_G   => BSA_BURST_BYTES_G,
          ENABLE_UNALIGN_G     => true,
+         FORCE_WRAP_ALIGN_G   => true,
          TRIGGER_USER_BIT_G   => 1,                                 -- EOFE is bit 0
          AXIL_BASE_ADDR_G     => DMA_RING_BASE_ADDR_C,
          DATA_AXIS_CONFIG_G   => LAST_STREAM_CONFIG_C,

--- a/BsaCore/rtl/BsssWrapper.vhd
+++ b/BsaCore/rtl/BsssWrapper.vhd
@@ -5,7 +5,7 @@
 -- Author     : Matt Weaver <weaver@slac.stanford.edu>
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2021-11-24
--- Last update: 2022-12-02
+-- Last update: 2022-12-15
 -- Platform   :
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
@@ -81,7 +81,7 @@ architecture rtl of BsssWrapper is
       packetSize  => START_COUNT,
       svcTsBit    => toSlv(11,4) );
 
-   constant BLD_CONFIG_BITS_C : integer := BSA_DIAGNOSTIC_OUTPUTS_C + 13;
+   constant BLD_CONFIG_BITS_C : integer := BSA_DIAGNOSTIC_OUTPUTS_C + 17;
 
    function toSlv(r : BldConfigType) return slv is
       variable v : slv(BLD_CONFIG_BITS_C-1 downto 0) := (others=>'0');
@@ -90,16 +90,18 @@ architecture rtl of BsssWrapper is
       assignSlv(i, v, r.enable);
       assignSlv(i, v, r.channelMask);
       assignSlv(i, v, r.packetSize);
+      assignSlv(i, v, r.svcTsBit);
       return v;
    end function;
 
    function toBldConfig(v : slv) return BldConfigType is
-      variable c : BldConfigType;
+      variable c : BldConfigType := BLD_CONFIG_INIT_C;
       variable i,j : integer := 0;
    begin
       assignRecord(i, v, c.enable);
       assignRecord(i, v, c.channelMask);
       assignRecord(i, v, c.packetSize);
+      assignRecord(i, v, c.svcTsBit);
       return c;
    end function;
 

--- a/BsaCore/yaml/BsssWrapper.yaml
+++ b/BsaCore/yaml/BsssWrapper.yaml
@@ -8,10 +8,10 @@
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
 #schemaversion 3.0.0
-#once BsssAxiStream.yaml
+#once BsssWrapper.yaml
 
-BsssAxiStream: &BsssAxiStream
-  name: BsssAxiStream
+BsssWrapper: &BsssWrapper
+  name: BsssWrapper
   description: Beam line data service
   size: 0x8000
   class: MMIODev
@@ -56,12 +56,13 @@ BsssAxiStream: &BsssAxiStream
       lsBit: 0
       mode: RW
       enums:
-          class: Enum
-          value: 0
         - name: INVALID_0
           class: Enum
-          value: 1
+          value: 0
         - name: INVALID_1
+          class: Enum
+          value: 1
+        - name: INVALID_2
           class: Enum
           value: 2
         - name: Limit_1p9_kHz


### PR DESCRIPTION
Fixes to v4.9.0 for the dma end addr misalignment, the svcTs bit for BSSS rate limits, and the number of EDEFs for BSAS.