### PR TITLE
RtmCryoDet - Pass LEMO_IN to application

### DIFF
--- a/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
@@ -216,7 +216,7 @@ architecture mapping of AmcCarrierCore is
 
 begin
 
-   assert (RSSI_ILEAVE_EN_G = false) or (RSSI_ILEAVE_EN_G and (DISABLE_BSA_G = false) and (DISABLE_BLD_G = false))
+   assert (RSSI_ILEAVE_EN_G = false) or (RSSI_ILEAVE_EN_G and DISABLE_BSA_G and DISABLE_BLD_G)
       report "RSSI Interleave + BSA or BLD is NOT supported" severity failure;
 
    -- Secondary AMC's Auxiliary Power (Default to allows active for the time being)

--- a/AppHardware/AmcMicrowaveMux/rtl/hmc305.vhd
+++ b/AppHardware/AmcMicrowaveMux/rtl/hmc305.vhd
@@ -205,16 +205,16 @@ begin
          CLK_PERIOD_G      => CLK_PERIOD_G,
          SPI_SCLK_PERIOD_G => SPI_SCLK_PERIOD_G)
       port map (
-         clk       => axiClk,
-         sRst      => axiRst,
-         chipSel   => "0",
-         wrEn      => r.wrEn,
-         wrData    => r.wrData,
-         rdEn      => rdEn,
-         rdData    => open,
-         spiCsL(0) => open,
-         spiSclk   => spiSck,
-         spiSdi    => spiSdi,
-         spiSdo    => '1');
+         clk     => axiClk,
+         sRst    => axiRst,
+         chipSel => "0",
+         wrEn    => r.wrEn,
+         wrData  => r.wrData,
+         rdEn    => rdEn,
+         rdData  => open,
+         spiCsL  => open,
+         spiSclk => spiSck,
+         spiSdi  => spiSdi,
+         spiSdo  => '1');
 
 end architecture rtl;

--- a/AppHardware/RtmCryoDet/rtl/RtmCryoDet.vhd
+++ b/AppHardware/RtmCryoDet/rtl/RtmCryoDet.vhd
@@ -62,8 +62,8 @@ entity RtmCryoDet is
       -- Application Ports --
       -----------------------
       -- RTM's Low Speed Ports
-      rtmLsP  : inout slv(53 downto 0);
-      rtmLsN  : inout slv(53 downto 0);
+      rtmLsP  : inout slv(53 downto 0) := (others => 'Z');
+      rtmLsN  : inout slv(53 downto 0) := (others => 'Z');
       --  RTM's Clock Reference
       genClkP : in    sl;
       genClkN : in    sl);

--- a/AppHardware/RtmCryoDet/rtl/RtmCryoDet.vhd
+++ b/AppHardware/RtmCryoDet/rtl/RtmCryoDet.vhd
@@ -37,33 +37,36 @@ entity RtmCryoDet is
       MMCM_CLK_DIV_G  : boolean          := false);
    port (
       -- JESD Clock Reference
-      jesdClk         : in    sl;
-      jesdRst         : in    sl;
+      jesdClk         : in  sl;
+      jesdRst         : in  sl;
       -- Timing trigger
-      timingTrig      : in    sl;
+      timingTrig      : in  sl;
       -- Digital I/O Interface
-      startRamp       : out   sl;
-      selectRamp      : out   sl;
-      rampCnt         : out   slv(31 downto 0);
+      startRamp       : out sl;
+      selectRamp      : out sl;
+      rampCnt         : out slv(31 downto 0);
       -- Copy of RTM DAC Configuration
-      rtmDacAddr      : in    slv(10 downto 0);
-      rtmDacData      : out   slv(19 downto 0);
+      rtmDacAddr      : in  slv(10 downto 0);
+      rtmDacData      : out slv(19 downto 0);
+      -- 1PPS Interface
+      lemoInRaw       : out sl;
       -- AXI-Lite
-      axilClk         : in    sl;
-      axilRst         : in    sl;
-      axilReadMaster  : in    AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
-      axilReadSlave   : out   AxiLiteReadSlaveType;
-      axilWriteMaster : in    AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
-      axilWriteSlave  : out   AxiLiteWriteSlaveType;
+      axilClk         : in  sl;
+      axilRst         : in  sl;
+      axilReadMaster  : in  AxiLiteReadMasterType  := AXI_LITE_READ_MASTER_INIT_C;
+      axilReadSlave   : out AxiLiteReadSlaveType;
+      axilWriteMaster : in  AxiLiteWriteMasterType := AXI_LITE_WRITE_MASTER_INIT_C;
+      axilWriteSlave  : out AxiLiteWriteSlaveType;
+
       -----------------------
       -- Application Ports --
       -----------------------
       -- RTM's Low Speed Ports
-      rtmLsP          : inout slv(53 downto 0);
-      rtmLsN          : inout slv(53 downto 0);
+      rtmLsP  : inout slv(53 downto 0);
+      rtmLsN  : inout slv(53 downto 0);
       --  RTM's Clock Reference
-      genClkP         : in    sl;
-      genClkN         : in    sl);
+      genClkP : in    sl;
+      genClkN : in    sl);
 end RtmCryoDet;
 
 architecture mapping of RtmCryoDet is
@@ -164,12 +167,13 @@ begin
    rtmLsP(3) <= picSck;
    rtmLsN(3) <= picSdi;
 
-   extTrig <= rtmLsP(7);                -- LEMO1
+   extTrig   <= rtmLsP(7);              -- LEMO1
+   lemoInRaw <= rtmLsP(7);
 
    ---------------------------------------------
    U_OREG_startRampPulse0 : ODDRE1
       generic map (
-         SIM_DEVICE => ite(ULTRASCALE_PLUS_C,"ULTRASCALE_PLUS","ULTRASCALE"))
+         SIM_DEVICE => ite(ULTRASCALE_PLUS_C, "ULTRASCALE_PLUS", "ULTRASCALE"))
       port map (
          C  => jesdClk,
          Q  => startRampPulseReg(0),
@@ -189,7 +193,7 @@ begin
    ---------------------------------------------
    U_OREG_startRampPulse1 : ODDRE1
       generic map (
-         SIM_DEVICE => ite(ULTRASCALE_PLUS_C,"ULTRASCALE_PLUS","ULTRASCALE"))
+         SIM_DEVICE => ite(ULTRASCALE_PLUS_C, "ULTRASCALE_PLUS", "ULTRASCALE"))
       port map (
          C  => jesdClk,
          Q  => startRampPulseReg(1),
@@ -462,7 +466,7 @@ begin
          TPD_G            => TPD_G,
          AXIL_BASE_ADDR_G => AXI_CONFIG_C(LUT_INDEX_C).baseAddr)
       port map (
-         hwTrig           => '0',  -- Mitch: Please connect this to the correct port.
+         hwTrig           => '0',       -- Mitch: Please connect this to the correct port.
          -- Clock and Reset
          axilClk          => axilClk,
          axilRst          => axilRst,

--- a/AppHardware/RtmCryoDet/rtl/RtmCryoDet.vhd
+++ b/AppHardware/RtmCryoDet/rtl/RtmCryoDet.vhd
@@ -226,7 +226,7 @@ begin
             clkIn           => jesdClk,
             rstIn           => '0',
             clkOut(0)       => jesdClkDivReg,
-            rstOut(0)       => open,
+            rstOut          => open,
             locked          => open);
    end generate GEN_MMCM_CLK_DIV;
 

--- a/python/AmcCarrierCore/AppHardware/RtmCryoDet/_spiCryo.py
+++ b/python/AmcCarrierCore/AppHardware/RtmCryoDet/_spiCryo.py
@@ -26,24 +26,24 @@ class SpiCryo(pr.Device):
             **kwargs):
         super().__init__(name=name, description=description, **kwargs)
 
-        ## _rawWrite/_rawRead
-        self.write_address = 0x0
-        self.read_address  = 0x4
-
-        self.relay_address = 0x2
-        self.hemt_bias_address = 0x3
-        self.a50K_bias_address = 0x4
-        self.temperature_address = 0x5
-        self.cycle_count_address = 0x6  # used for testing
-        self.ps_en_address = 0x7 # PS enable (HEMT: bit 0, 50k: bit 1)
-        self.ac_dc_status_address = 0x8 # AC/DC mode status (bit 0: FRN_RLY, bit 1: FRP_RLY)
-        self.adc_scale = 3.3/(1024.0 * 5)
-        self.temperature_scale = 1/.028 # was 100
-        self.temperature_offset =.25
-        self.bias_scale = 1.0
-        self.max_retries = 5  #number of re-tries waiting for response
-        self.retry = 0 # counts nubmer of retries
-        self.busy_retry = 0  # counts number of retries due to relay busy status
+        ## ## _rawWrite/_rawRead
+        ## self.write_address = 0x0
+        ## self.read_address  = 0x4
+        ## 
+        ## self.relay_address = 0x2
+        ## self.hemt_bias_address = 0x3
+        ## self.a50K_bias_address = 0x4
+        ## self.temperature_address = 0x5
+        ## self.cycle_count_address = 0x6  # used for testing
+        ## self.ps_en_address = 0x7 # PS enable (HEMT: bit 0, 50k: bit 1)
+        ## self.ac_dc_status_address = 0x8 # AC/DC mode status (bit 0: FRN_RLY, bit 1: FRP_RLY)
+        ## self.adc_scale = 3.3/(1024.0 * 5)
+        ## self.temperature_scale = 1/.028 # was 100
+        ## self.temperature_offset =.25
+        ## self.bias_scale = 1.0
+        ## self.max_retries = 5  #number of re-tries waiting for response
+        ## self.retry = 0 # counts nubmer of retries
+        ## self.busy_retry = 0  # counts number of retries due to relay busy status
 
         self.add(pr.RemoteVariable(
             name        = "write",
@@ -65,86 +65,91 @@ class SpiCryo(pr.Device):
             hidden      = True,
         ))
 
-        self.add(pr.LinkVariable(
-            name         = "temperature",
-            description  = "temperature",
-            dependencies = [],
-            linkedGet    = lambda dev, var, read: dev.read_temperature(dev, var, read),
-            typeStr      = "Float64",
-            mode         = "RO",
-        ))
+        ## 6/12/23 - SWH commented out ; someone started trying to
+        ## move cryostat card interface into rogue but not working.
+        ## Good idea, leaving to maybe complete later.
+        ##
+        ## self.add(pr.LinkVariable(
+        ##     name         = "temperature",
+        ##     description  = "temperature",
+        ##     dependencies = [],
+        ##     linkedGet    = lambda dev, var, read: dev.read_temperature(dev, var, read),
+        ##     typeStr      = "Float64",
+        ##     mode         = "RO",
+        ## ))
+        ## 
+        ## self.add(pr.LinkVariable(
+        ##     name         = "50kBias",
+        ##     description  = "temperature",
+        ##     dependencies = [],
+        ##     linkedGet    = lambda dev, var, read: dev.read_50k_bias(dev, var, read),
+        ##     typeStr      = "Float64",
+        ##     mode         = "RO",
+        ## ))
+        ## 
+        ## self.add(pr.LinkVariable(
+        ##     name         = "hemtBias",
+        ##     description  = "hemtBias",
+        ##     dependencies = [],
+        ##     linkedGet    = lambda dev, var, read: dev.read_hemt_bias(dev, var, read),
+        ##     typeStr      = "Float64",
+        ##     mode         = "RO",
+        ## ))
 
-        self.add(pr.LinkVariable(
-            name         = "50kBias",
-            description  = "temperature",
-            dependencies = [],
-            linkedGet    = lambda dev, var, read: dev.read_50k_bias(dev, var, read),
-            typeStr      = "Float64",
-            mode         = "RO",
-        ))
-
-
-
-        self.add(pr.LinkVariable(
-            name         = "hemtBias",
-            description  = "hemtBias",
-            dependencies = [],
-            linkedGet    = lambda dev, var, read: dev.read_hemt_bias(dev, var, read),
-            typeStr      = "Float64",
-            mode         = "RO",
-        ))
-
-
-    def cmd_read(self, data):  # checks for a read bit set in data
-        return ( (data & 0x80000000) != 0)
-
-    def cmd_address(self, data): # returns address data
-        return ((data & 0x7FFF0000) >> 20)
-
-    def cmd_data(self, data):  # returns data
-        return (data & 0xFFFFF)
-
-    def cmd_make(self, read, address, data):
-        return ((read << 31) | ((address << 20) & 0x7FFF00000) | (data & 0xFFFFF))
-
-    def do_read(self, address):
-        #need double write to make sure buffer is updated
-        self._rawWrite(self.write_address, self.cmd_make(1, address, 0))
-        for self.retry in range(0, self.max_retries):
-            self._rawWrite(self.write_address, self.cmd_make(1, address, 0))
-            data = self._rawRead(self.read_address)
-            addrrb = self.cmd_address(data)
-            if (addrrb == address):
-                return (data)
-        return (0)
-
-    @staticmethod
-    def read_temperature(dev, var, read):
-        data = dev.do_read(dev.temperature_address)
-        volts = (data & 0xFFFFF) * dev.adc_scale
-        return round(((volts - dev.temperature_offset) * dev.temperature_scale),2)
-
-    @staticmethod
-    def write_relays(dev, var, value):  # relay is the bit partern to set
-        dev._rawWrite(dev.write_address, dev.cmd_make(0, dev.relay_address, value))
-        time.sleep(0.1)
-        dev._rawWrite(dev.write_address, dev.cmd_make(0, dev.relay_address, value))
-
-    @staticmethod
-    def read_relays(dev, var, read):
-        for dev.busy_retry in range(0, dev.max_retries):
-            data = dev.do_read(dev.relay_address)
-            if ~(data & 0x80000):  # check that not moving
-                return (data & 0x7FFFF)
-                time.sleep(0.1) # wait for relays to move
-        return (80000) # busy flag still set
-
-    @staticmethod
-    def read_hemt_bias(dev, var, read):
-        data = dev.do_read(dev.hemt_bias_address)
-        return round(((data& 0xFFFFF) * dev.bias_scale * dev.adc_scale),6)
-
-    @staticmethod
-    def read_50k_bias(dev, var, read):
-        data = dev.do_read(dev.a50K_bias_address)
-        return round(((data& 0xFFFFF) * dev.bias_scale * dev.adc_scale), 6)
+    ## 6/12/23 - SWH commented out ; someone started trying to
+    ## move cryostat card interface into rogue but not working.
+    ## Good idea, leaving to maybe complete later.
+    ##
+    ## def cmd_read(self, data):  # checks for a read bit set in data
+    ##     return ( (data & 0x80000000) != 0)
+    ## 
+    ## def cmd_address(self, data): # returns address data
+    ##     return ((data & 0x7FFF0000) >> 20)
+    ## 
+    ## def cmd_data(self, data):  # returns data
+    ##     return (data & 0xFFFFF)
+    ## 
+    ## def cmd_make(self, read, address, data):
+    ##     return ((read << 31) | ((address << 20) & 0x7FFF00000) | (data & 0xFFFFF))
+    ## 
+    ## def do_read(self, address):
+    ##     #need double write to make sure buffer is updated
+    ##     self._rawWrite(self.write_address, self.cmd_make(1, address, 0))
+    ##     for self.retry in range(0, self.max_retries):
+    ##         self._rawWrite(self.write_address, self.cmd_make(1, address, 0))
+    ##         data = self._rawRead(self.read_address)
+    ##         addrrb = self.cmd_address(data)
+    ##         if (addrrb == address):
+    ##             return (data)
+    ##     return (0)
+    ## 
+    ## @staticmethod
+    ## def read_temperature(dev, var, read):
+    ##     data = dev.do_read(dev.temperature_address)
+    ##     volts = (data & 0xFFFFF) * dev.adc_scale
+    ##     return round(((volts - dev.temperature_offset) * dev.temperature_scale),2)
+    ## 
+    ## @staticmethod
+    ## def write_relays(dev, var, value):  # relay is the bit partern to set
+    ##     dev._rawWrite(dev.write_address, dev.cmd_make(0, dev.relay_address, value))
+    ##     time.sleep(0.1)
+    ##     dev._rawWrite(dev.write_address, dev.cmd_make(0, dev.relay_address, value))
+    ## 
+    ## @staticmethod
+    ## def read_relays(dev, var, read):
+    ##     for dev.busy_retry in range(0, dev.max_retries):
+    ##         data = dev.do_read(dev.relay_address)
+    ##         if ~(data & 0x80000):  # check that not moving
+    ##             return (data & 0x7FFFF)
+    ##             time.sleep(0.1) # wait for relays to move
+    ##     return (80000) # busy flag still set
+    ## 
+    ## @staticmethod
+    ## def read_hemt_bias(dev, var, read):
+    ##     data = dev.do_read(dev.hemt_bias_address)
+    ##     return round(((data& 0xFFFFF) * dev.bias_scale * dev.adc_scale),6)
+    ## 
+    ## @staticmethod
+    ## def read_50k_bias(dev, var, read):
+    ##     data = dev.do_read(dev.a50K_bias_address)
+    ##     return round(((data& 0xFFFFF) * dev.bias_scale * dev.adc_scale), 6)

--- a/python/AmcCarrierCore/AppHardware/RtmCryoDet/_spiCryo.py
+++ b/python/AmcCarrierCore/AppHardware/RtmCryoDet/_spiCryo.py
@@ -29,7 +29,7 @@ class SpiCryo(pr.Device):
         ## ## _rawWrite/_rawRead
         ## self.write_address = 0x0
         ## self.read_address  = 0x4
-        ## 
+        ##
         ## self.relay_address = 0x2
         ## self.hemt_bias_address = 0x3
         ## self.a50K_bias_address = 0x4
@@ -77,7 +77,7 @@ class SpiCryo(pr.Device):
         ##     typeStr      = "Float64",
         ##     mode         = "RO",
         ## ))
-        ## 
+        ##
         ## self.add(pr.LinkVariable(
         ##     name         = "50kBias",
         ##     description  = "temperature",
@@ -86,7 +86,7 @@ class SpiCryo(pr.Device):
         ##     typeStr      = "Float64",
         ##     mode         = "RO",
         ## ))
-        ## 
+        ##
         ## self.add(pr.LinkVariable(
         ##     name         = "hemtBias",
         ##     description  = "hemtBias",
@@ -102,16 +102,16 @@ class SpiCryo(pr.Device):
     ##
     ## def cmd_read(self, data):  # checks for a read bit set in data
     ##     return ( (data & 0x80000000) != 0)
-    ## 
+    ##
     ## def cmd_address(self, data): # returns address data
     ##     return ((data & 0x7FFF0000) >> 20)
-    ## 
+    ##
     ## def cmd_data(self, data):  # returns data
     ##     return (data & 0xFFFFF)
-    ## 
+    ##
     ## def cmd_make(self, read, address, data):
     ##     return ((read << 31) | ((address << 20) & 0x7FFF00000) | (data & 0xFFFFF))
-    ## 
+    ##
     ## def do_read(self, address):
     ##     #need double write to make sure buffer is updated
     ##     self._rawWrite(self.write_address, self.cmd_make(1, address, 0))
@@ -122,19 +122,19 @@ class SpiCryo(pr.Device):
     ##         if (addrrb == address):
     ##             return (data)
     ##     return (0)
-    ## 
+    ##
     ## @staticmethod
     ## def read_temperature(dev, var, read):
     ##     data = dev.do_read(dev.temperature_address)
     ##     volts = (data & 0xFFFFF) * dev.adc_scale
     ##     return round(((volts - dev.temperature_offset) * dev.temperature_scale),2)
-    ## 
+    ##
     ## @staticmethod
     ## def write_relays(dev, var, value):  # relay is the bit partern to set
     ##     dev._rawWrite(dev.write_address, dev.cmd_make(0, dev.relay_address, value))
     ##     time.sleep(0.1)
     ##     dev._rawWrite(dev.write_address, dev.cmd_make(0, dev.relay_address, value))
-    ## 
+    ##
     ## @staticmethod
     ## def read_relays(dev, var, read):
     ##     for dev.busy_retry in range(0, dev.max_retries):
@@ -143,12 +143,12 @@ class SpiCryo(pr.Device):
     ##             return (data & 0x7FFFF)
     ##             time.sleep(0.1) # wait for relays to move
     ##     return (80000) # busy flag still set
-    ## 
+    ##
     ## @staticmethod
     ## def read_hemt_bias(dev, var, read):
     ##     data = dev.do_read(dev.hemt_bias_address)
     ##     return round(((data& 0xFFFFF) * dev.bias_scale * dev.adc_scale),6)
-    ## 
+    ##
     ## @staticmethod
     ## def read_50k_bias(dev, var, read):
     ##     data = dev.do_read(dev.a50K_bias_address)

--- a/python/AmcCarrierCore/AppHardware/RtmCryoDet/_spiCryo.py
+++ b/python/AmcCarrierCore/AppHardware/RtmCryoDet/_spiCryo.py
@@ -17,7 +17,7 @@
 #-----------------------------------------------------------------------------
 
 import pyrogue as pr
-import time
+#import time
 
 class SpiCryo(pr.Device):
     def __init__(   self,


### PR DESCRIPTION
- Allow the CryoDet RTM `LEMO_IN` signal to pass directly to the application firmware. It is also still used for the ramp stuff, but this could maybe be deleted.
- Fix an incorrect assert statement to allow interleaved RSSI that was introduced in #364.
- Clean up VHDL syntax for xsim simulation.
- Remove unfinished cryocard readback and control from rogue code.