### PR TITLE
Updating python/AmcCarrierCore/AppHardware/RtmCryoDet/_spiMax.py

### DIFF
--- a/python/AmcCarrierCore/AppHardware/RtmCryoDet/_spiMax.py
+++ b/python/AmcCarrierCore/AppHardware/RtmCryoDet/_spiMax.py
@@ -65,6 +65,7 @@ class SpiMax(pr.Device):
                 offset       =  0x00 + (i+8),
                 bitSize      =  20,
                 bitOffset    =  0x00,
+                value        =  0x2,
                 base         = pr.UInt,
                 mode         = "RW",
             ))


### PR DESCRIPTION
#### Description
- Default of 0x2 for DacCtrlRegCh registers keeps precision SMuRF slow DACs from railing negative during setDefaults.  See ESCRYODET-924 for more details.
