### PR TITLE
Release Candidate v5.0.0

### DIFF
--- a/AmcCarrierCore/core/AmcCarrierPkg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierPkg.vhd
@@ -25,8 +25,8 @@ use lcls_timing_core.TimingPkg.all;
 
 package AmcCarrierPkg is
 
-   -- https://github.com/slaclab/amc-carrier-core/releases/tag/v4.12.1
-   constant AMC_CARRIER_CORE_VERSION_C : slv(31 downto 0) := x"04_12_01_00";
+   -- https://github.com/slaclab/amc-carrier-core/releases/tag/v5.0.0
+   constant AMC_CARRIER_CORE_VERSION_C : slv(31 downto 0) := x"05_00_00_00";
 
    -----------------------------------------------------------
    -- Application: Configurations, Constants and Records Types

--- a/AppTop/rtl/xcku040/AppTop.vhd
+++ b/AppTop/rtl/xcku040/AppTop.vhd
@@ -188,6 +188,12 @@ architecture mapping of AppTop is
    signal jesdRxSync : slv(1 downto 0);
    signal jesdTxSync : Slv7Array(1 downto 0);
 
+   signal appTimingClk : sl;
+   signal appTimingRst : sl;
+
+   signal timingClkb : sl;
+   signal timingRstb : sl;
+
    signal adcValids : Slv7Array(1 downto 0);
    signal adcValues : sampleDataVectorArray(1 downto 0, 6 downto 0);
 
@@ -215,49 +221,57 @@ begin
            (TIMING_BUS_DOMAIN_G = "JESD_2xCLK1") or
            (TIMING_BUS_DOMAIN_G = "JESD_UsrCLK0") or
            (TIMING_BUS_DOMAIN_G = "JESD_UsrCLK1") or
-           (TIMING_BUS_DOMAIN_G = "AXI_LITE"))
-      report "TIMING_BUS_DOMAIN_G be either [REC_CLK,AXI_LITE,JESD_CLK0,JESD_CLK1,JESD_2xCLK0,JESD_2xCLK1,JESD_UsrCLK0,JESD_UsrCLK1]" severity error;
+           (TIMING_BUS_DOMAIN_G = "AXI_LITE") or
+           (TIMING_BUS_DOMAIN_G = "APP_CLK"))
+      report "TIMING_BUS_DOMAIN_G be either [REC_CLK,AXI_LITE,APP_CLK,JESD_CLK0,JESD_CLK1,JESD_2xCLK0,JESD_2xCLK1,JESD_UsrCLK0,JESD_UsrCLK1]" severity error;
 
+   timingClk <= timingClkb;
+   timingRst <= timingRstb;
+   
    --------------------------
    -- Clock and reset mapping
    --------------------------
    process(axilClk, axilRst, jesdClk, jesdClk2x, jesdRst, jesdRst2x,
-           jesdUsrClk, jesdUsrRst, recTimingClk, recTimingRst)
+           jesdUsrClk, jesdUsrRst, recTimingClk, recTimingRst, appTimingClk, appTimingRst)
    begin
       case TIMING_BUS_DOMAIN_G is
          ------------------------------
          when "REC_CLK" =>
-            timingClk <= recTimingClk;
-            timingRst <= recTimingRst;
+            timingClkb <= recTimingClk;
+            timingRstb <= recTimingRst;
+         ------------------------------
+         when "APP_CLK" =>
+            timingClkb <= appTimingClk;
+            timingRstb <= appTimingRst;
          ------------------------------
          when "JESD_CLK0" =>
-            timingClk <= jesdClk(0);
-            timingRst <= jesdRst(0);
+            timingClkb <= jesdClk(0);
+            timingRstb <= jesdRst(0);
          ------------------------------
          when "JESD_CLK1" =>
-            timingClk <= jesdClk(1);
-            timingRst <= jesdRst(1);
+            timingClkb <= jesdClk(1);
+            timingRstb <= jesdRst(1);
          ------------------------------
          when "JESD_2xCLK0" =>
-            timingClk <= jesdClk2x(0);
-            timingRst <= jesdRst2x(0);
+            timingClkb <= jesdClk2x(0);
+            timingRstb <= jesdRst2x(0);
          ------------------------------
          when "JESD_2xCLK1" =>
-            timingClk <= jesdClk2x(1);
-            timingRst <= jesdRst2x(1);
+            timingClkb <= jesdClk2x(1);
+            timingRstb <= jesdRst2x(1);
          ------------------------------
          when "JESD_UsrCLK0" =>
-            timingClk <= jesdUsrClk(0);
-            timingRst <= jesdUsrRst(0);
+            timingClkb <= jesdUsrClk(0);
+            timingRstb <= jesdUsrRst(0);
          ------------------------------
          when "JESD_UsrCLK1" =>
-            timingClk <= jesdUsrClk(1);
-            timingRst <= jesdUsrRst(1);
+            timingClkb <= jesdUsrClk(1);
+            timingRstb <= jesdUsrRst(1);
          ------------------------------
          when others =>
             -- (TIMING_BUS_DOMAIN_G = "AXI-LITE")
-            timingClk <= axilClk;
-            timingRst <= axilRst;
+            timingClkb <= axilClk;
+            timingRstb <= axilRst;
       ------------------------------
       end case;
    end process;
@@ -488,6 +502,8 @@ begin
          jesdRst2x           => jesdRst2x,
          jesdUsrClk          => jesdUsrClk,
          jesdUsrRst          => jesdUsrRst,
+         appTimingClk        => appTimingClk,
+         appTimingRst        => appTimingRst,
          -- DaqMux/Trig Interface (timingClk domain)
          freezeHw            => freezeHw,
          timingTrig          => timingTrig,
@@ -523,8 +539,10 @@ begin
          -- Top Level Interface
          ----------------------
          -- Timing Interface (timingClk domain)
-         timingClk           => recTimingClk,
-         timingRst           => recTimingRst,
+         recTimingClk        => recTimingClk,
+         recTimingRst        => recTimingRst,
+         timingClk           => timingClkb,
+         timingRst           => timingRstb,
          timingBus           => timingBus,
          timingPhy           => timingPhy,
          timingPhyClk        => timingPhyClk,

--- a/AppTop/rtl/xcku060/AppTop.vhd
+++ b/AppTop/rtl/xcku060/AppTop.vhd
@@ -188,6 +188,12 @@ architecture mapping of AppTop is
    signal jesdRxSync : slv(1 downto 0);
    signal jesdTxSync : Slv10Array(1 downto 0);
 
+   signal appTimingClk : sl;
+   signal appTimingRst : sl;
+
+   signal timingClkb : sl;
+   signal timingRstb : sl;
+
    signal adcValids : Slv10Array(1 downto 0);
    signal adcValues : sampleDataVectorArray(1 downto 0, 9 downto 0);
 
@@ -215,49 +221,57 @@ begin
            (TIMING_BUS_DOMAIN_G = "JESD_2xCLK1") or
            (TIMING_BUS_DOMAIN_G = "JESD_UsrCLK0") or
            (TIMING_BUS_DOMAIN_G = "JESD_UsrCLK1") or
-           (TIMING_BUS_DOMAIN_G = "AXI_LITE"))
-      report "TIMING_BUS_DOMAIN_G be either [REC_CLK,AXI_LITE,JESD_CLK0,JESD_CLK1,JESD_2xCLK0,JESD_2xCLK1,JESD_UsrCLK0,JESD_UsrCLK1]" severity error;
+           (TIMING_BUS_DOMAIN_G = "AXI_LITE") or
+           (TIMING_BUS_DOMAIN_G = "APP_CLK"))
+      report "TIMING_BUS_DOMAIN_G be either [REC_CLK,AXI_LITE,APP_CLK,,JESD_CLK0,JESD_CLK1,JESD_2xCLK0,JESD_2xCLK1,JESD_UsrCLK0,JESD_UsrCLK1]" severity error;
 
+   timingClk <= timingClkb;
+   timingRst <= timingRstb;
+   
    --------------------------
    -- Clock and reset mapping
    --------------------------
    process(axilClk, axilRst, jesdClk, jesdClk2x, jesdRst, jesdRst2x,
-           jesdUsrClk, jesdUsrRst, recTimingClk, recTimingRst)
+           jesdUsrClk, jesdUsrRst, recTimingClk, recTimingRst, appTimingClk, appTimingRst)
    begin
       case TIMING_BUS_DOMAIN_G is
          ------------------------------
          when "REC_CLK" =>
-            timingClk <= recTimingClk;
-            timingRst <= recTimingRst;
+            timingClkb <= recTimingClk;
+            timingRstb <= recTimingRst;
+         ------------------------------
+         when "APP_CLK" =>
+            timingClkb <= appTimingClk;
+            timingRstb <= appTimingRst;
          ------------------------------
          when "JESD_CLK0" =>
-            timingClk <= jesdClk(0);
-            timingRst <= jesdRst(0);
+            timingClkb <= jesdClk(0);
+            timingRstb <= jesdRst(0);
          ------------------------------
          when "JESD_CLK1" =>
-            timingClk <= jesdClk(1);
-            timingRst <= jesdRst(1);
+            timingClkb <= jesdClk(1);
+            timingRstb <= jesdRst(1);
          ------------------------------
          when "JESD_2xCLK0" =>
-            timingClk <= jesdClk2x(0);
-            timingRst <= jesdRst2x(0);
+            timingClkb <= jesdClk2x(0);
+            timingRstb <= jesdRst2x(0);
          ------------------------------
          when "JESD_2xCLK1" =>
-            timingClk <= jesdClk2x(1);
-            timingRst <= jesdRst2x(1);
+            timingClkb <= jesdClk2x(1);
+            timingRstb <= jesdRst2x(1);
          ------------------------------
          when "JESD_UsrCLK0" =>
-            timingClk <= jesdUsrClk(0);
-            timingRst <= jesdUsrRst(0);
+            timingClkb <= jesdUsrClk(0);
+            timingRstb <= jesdUsrRst(0);
          ------------------------------
          when "JESD_UsrCLK1" =>
-            timingClk <= jesdUsrClk(1);
-            timingRst <= jesdUsrRst(1);
+            timingClkb <= jesdUsrClk(1);
+            timingRstb <= jesdUsrRst(1);
          ------------------------------
          when others =>
             -- (TIMING_BUS_DOMAIN_G = "AXI-LITE")
-            timingClk <= axilClk;
-            timingRst <= axilRst;
+            timingClkb <= axilClk;
+            timingRstb <= axilRst;
       ------------------------------
       end case;
    end process;
@@ -506,6 +520,8 @@ begin
          jesdRst2x           => jesdRst2x,
          jesdUsrClk          => jesdUsrClk,
          jesdUsrRst          => jesdUsrRst,
+         appTimingClk        => appTimingClk,
+         appTimingRst        => appTimingRst,
          -- DaqMux/Trig Interface (timingClk domain)
          freezeHw            => freezeHw,
          timingTrig          => timingTrig,
@@ -541,8 +557,10 @@ begin
          -- Top Level Interface
          ----------------------
          -- Timing Interface (timingClk domain)
-         timingClk           => recTimingClk,
-         timingRst           => recTimingRst,
+         recTimingClk        => recTimingClk,
+         recTimingRst        => recTimingRst,
+         timingClk           => timingClkb,
+         timingRst           => timingRstb,
          timingBus           => timingBus,
          timingPhy           => timingPhy,
          timingPhyClk        => timingPhyClk,

--- a/AppTop/ruckus.tcl
+++ b/AppTop/ruckus.tcl
@@ -6,7 +6,8 @@ loadSource -lib amc_carrier_core           -dir  "$::DIR_PATH/rtl"
 loadSource -lib amc_carrier_core -sim_only -dir  "$::DIR_PATH/tb/"
 
 # Check for valid FPGA
-if { $::env(PRJ_PART) == "XCKU040-FFVA1156-2-E" } {
+if { $::env(PRJ_PART) == "XCKU040-FFVA1156-2-E" ||
+     $::env(USE_APPTOP_040_INTF) == 1 } {
    loadConstraints -path "$::DIR_PATH/xdc/AppTop_gen1.xdc"
 
    if { [info exists ::env(APP_MPS_LNODE)] != 1 || $::env(APP_MPS_LNODE) == 0 } {

--- a/AppTop/ruckus.tcl
+++ b/AppTop/ruckus.tcl
@@ -5,9 +5,16 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 loadSource -lib amc_carrier_core           -dir  "$::DIR_PATH/rtl"
 loadSource -lib amc_carrier_core -sim_only -dir  "$::DIR_PATH/tb/"
 
+# Checking for new amc-carrier-core@v5.0.0 that may not exist in older projects
+if { [info exists ::env(USE_APPTOP_040_INTF)] != 1 || $::env(USE_APPTOP_040_INTF) == 0 } {
+   set USE_APPTOP_040_INTF 0
+} else {
+   set USE_APPTOP_040_INTF 1
+}
+
 # Check for valid FPGA
 if { $::env(PRJ_PART) == "XCKU040-FFVA1156-2-E" ||
-     $::env(USE_APPTOP_040_INTF) == 1 } {
+     ${USE_APPTOP_040_INTF} == 1 } {
    loadConstraints -path "$::DIR_PATH/xdc/AppTop_gen1.xdc"
 
    if { [info exists ::env(APP_MPS_LNODE)] != 1 || $::env(APP_MPS_LNODE) == 0 } {

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -8,9 +8,9 @@ if { [VersionCheck 2018.3 ] < 0 } {
 
 # Check for submodule tagging
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
-   if { [SubmoduleCheck {lcls-timing-core} {3.7.7}  "mustBeExact" ] < 0 } {exit -1}
-   if { [SubmoduleCheck {ruckus}           {4.9.0}  "mustBeExact" ] < 0 } {exit -1}
-   if { [SubmoduleCheck {surf}             {2.45.4} "mustBeExact" ] < 0 } {exit -1}
+   if { [SubmoduleCheck {lcls-timing-core} {3.8.0}  "mustBeExact" ] < 0 } {exit -1}
+   if { [SubmoduleCheck {ruckus}           {4.10.1} "mustBeExact" ] < 0 } {exit -1}
+   if { [SubmoduleCheck {surf}             {2.47.1} "mustBeExact" ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"
    puts "OVERRIDE_SUBMODULE_LOCKS != 0"


### PR DESCRIPTION
#### Description
- https://github.com/slaclab/amc-carrier-core/pull/405 is `API BREAKING` change:
  - Requires that the AppCore adds `appTimingClk`  and `appTimingRst` 
  - This option to use application supplied clock from AppCore for timing.  
  - [example of how to update your AppCore.vhd for amc-carrier-core@v5.0.0](https://github.com/slaclab/amc-carrier-project-template/commit/a03a777f714c1efb5749627ea146c35eee393a7a)
- Add build option to use KCU040 modules with KCU060 FPGA target.