### PR TITLE
reorg of the ref125MHzClk used for linkNode and appNode

### DIFF
--- a/AmcCarrierCore/fsbl/AmcCarrierCoreFsbl.vhd
+++ b/AmcCarrierCore/fsbl/AmcCarrierCoreFsbl.vhd
@@ -214,6 +214,10 @@ architecture mapping of AmcCarrierCoreFsbl is
 
    signal ref156MHzClk  : sl;
    signal ref156MHzRst  : sl;
+
+   signal ref125MHzClk  : sl;
+   signal ref125MHzRst  : sl;
+
    signal bsiBus        : BsiBusType;
    signal timingBusIntf : TimingBusType;
 
@@ -345,6 +349,8 @@ begin
          -- Core Ports --
          ----------------
          -- Backplane MPS Ports
+         ref125MHzClk    => ref125MHzClk,
+         ref125MHzRst    => ref125MHzRst,
          mpsClkIn        => mpsClkIn,
          mpsClkOut       => mpsClkOut,
          mpsBusRxP       => mpsBusRxP,
@@ -402,6 +408,8 @@ begin
          recTimingRst         => recTimingRst,
          ref156MHzClk         => ref156MHzClk,
          ref156MHzRst         => ref156MHzRst,
+         ref125MHzClk         => ref125MHzClk,
+         ref125MHzRst         => ref125MHzRst,
          gthFabClk            => gthFabClk,
          ------------------------
          -- Core Ports to Wrapper

--- a/AmcCarrierCore/fsbl/AmcCarrierFsbl.vhd
+++ b/AmcCarrierCore/fsbl/AmcCarrierFsbl.vhd
@@ -79,6 +79,8 @@ entity AmcCarrierFsbl is
       recTimingRst         : out   sl;
       ref156MHzClk         : out   sl;
       ref156MHzRst         : out   sl;
+      ref125MHzClk         : out   sl;
+      ref125MHzRst         : out   sl;
       gthFabClk            : out   sl;
       ------------------------
       -- Core Ports to Wrapper
@@ -253,21 +255,24 @@ begin
          INPUT_BUFG_G      => true,
          FB_BUFG_G         => true,
          RST_IN_POLARITY_G => '1',
-         NUM_CLOCKS_G      => 1,
+         NUM_CLOCKS_G      => 2,
          -- MMCM attributes
          BANDWIDTH_G       => "OPTIMIZED",
          CLKIN_PERIOD_G    => 6.4,
          DIVCLK_DIVIDE_G   => 1,
          CLKFBOUT_MULT_G   => 8,
-         CLKOUT0_DIVIDE_G  => 8)
+         CLKOUT0_DIVIDE_G  => 8,
+         CLKOUT1_DIVIDE_G  => 10)
       port map(
          -- Clock Input
          clkIn     => fabClk,
          rstIn     => fabRst,
          -- Clock Outputs
          clkOut(0) => axilClk,
+         clkOut(1) => ref125MHzClk,
          -- Reset Outputs
-         rstOut(0) => reset);
+         rstOut(0) => reset,
+         rstOut(1) => ref125MHzRst);
 
    -- Forcing BUFG for reset that's used everywhere
    U_BUFG : BUFG

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
@@ -99,6 +99,8 @@ entity AmcCarrierCore is
       recTimingRst         : out   sl;
       ref156MHzClk         : out   sl;
       ref156MHzRst         : out   sl;
+      ref125MHzClk         : out   sl;
+      ref125MHzRst         : out   sl;
       stableClk            : out   sl;
       stableRst            : out   sl;
       gthFabClk            : out   sl;
@@ -285,21 +287,24 @@ begin
          INPUT_BUFG_G      => true,
          FB_BUFG_G         => true,
          RST_IN_POLARITY_G => '1',
-         NUM_CLOCKS_G      => 1,
+         NUM_CLOCKS_G      => 2,
          -- MMCM attributes
          BANDWIDTH_G       => "OPTIMIZED",
          CLKIN_PERIOD_G    => 12.8,     -- 78.125MHz
          DIVCLK_DIVIDE_G   => 1,        -- 78.125MHz = 78.125MHz/1
          CLKFBOUT_MULT_G   => 16,       -- 1.25GHz=78.125MHz*16
-         CLKOUT0_DIVIDE_G  => 8)        -- 156.25MHz=1.25GHz/8
+         CLKOUT0_DIVIDE_G  => 8,        -- 156.25MHz=1.25GHz/8
+         CLKOUT1_DIVIDE_G  => 10)       -- 125MHz=1.25GHz/10
       port map(
          -- Clock Input
          clkIn     => fabClk,
          rstIn     => fabRst,
          -- Clock Outputs
          clkOut(0) => axilClk,
+         clkOut(1) => ref125MHzClk,
          -- Reset Outputs
-         rstOut(0) => reset);
+         rstOut(0) => reset,
+         rstOut(1) => ref125MHzRst);
 
    -- Help with meeting timing on the reset path
    U_Rst : entity surf.RstPipeline

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCoreAdv.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCoreAdv.vhd
@@ -241,6 +241,10 @@ architecture mapping of AmcCarrierCoreAdv is
 
    signal ref156MHzClk  : sl;
    signal ref156MHzRst  : sl;
+
+   signal ref125MHzClk  : sl;
+   signal ref125MHzRst  : sl;
+
    signal bsiBus        : BsiBusType;
    signal timingBusIntf : TimingBusType;
 
@@ -384,6 +388,8 @@ begin
             -- Core Ports --
             ----------------
             -- Backplane MPS Ports
+            ref125MHzClk    => ref125MHzClk,
+            ref125MHzRst    => ref125MHzRst,
             mpsClkIn        => mpsClkIn,
             mpsClkOut       => mpsClkOut,
             mpsBusRxP       => mpsBusRxP,
@@ -473,6 +479,8 @@ begin
          recTimingRst         => recTimingRst,
          ref156MHzClk         => ref156MHzClk,
          ref156MHzRst         => ref156MHzRst,
+         ref125MHzClk         => ref125MHzClk,
+         ref125MHzRst         => ref125MHzRst,
          gthFabClk            => gthFabClk,
          stableClk            => stableClk,
          stableRst            => stableRst,

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCoreBase.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCoreBase.vhd
@@ -241,6 +241,10 @@ architecture mapping of AmcCarrierCoreBase is
 
    signal ref156MHzClk  : sl;
    signal ref156MHzRst  : sl;
+
+   signal ref125MHzClk  : sl;
+   signal ref125MHzRst  : sl;
+
    signal bsiBus        : BsiBusType;
    signal timingBusIntf : TimingBusType;
 
@@ -384,6 +388,8 @@ begin
             -- Core Ports --
             ----------------
             -- Backplane MPS Ports
+            ref125MHzClk    => ref125MHzClk,
+            ref125MHzRst    => ref125MHzRst,
             mpsClkIn        => mpsClkIn,
             mpsClkOut       => mpsClkOut,
             mpsBusRxP       => mpsBusRxP,
@@ -473,6 +479,8 @@ begin
          recTimingRst         => recTimingRst,
          ref156MHzClk         => ref156MHzClk,
          ref156MHzRst         => ref156MHzRst,
+         ref125MHzClk         => ref125MHzClk,
+         ref125MHzRst         => ref125MHzRst,
          gthFabClk            => gthFabClk,
          stableClk            => stableClk,
          stableRst            => stableRst,

--- a/AppMps/rtl/AppMps.vhd
+++ b/AppMps/rtl/AppMps.vhd
@@ -73,6 +73,8 @@ entity AppMps is
       -- Core Ports --
       ----------------
       -- Backplane MPS Ports
+      ref125MHzClk    : in  sl;
+      ref125MHzRst    : in  sl;
       mpsClkIn        : in  sl;
       mpsClkOut       : out sl;
       mpsBusRxP       : in  slv(14 downto 1);
@@ -150,6 +152,8 @@ begin
          -- Core Ports --
          ----------------
          -- Backplane MPS Ports
+         ref125MHzClk => ref125MHzClk,
+         ref125MHzRst => ref125MHzRst,
          mpsClkIn     => mpsClkIn,
          mpsClkOut    => mpsClkOut);
 


### PR DESCRIPTION
### Description
- Creating a 125 MHz on the same PLL as AXI-Lite to reduce the number of cascaded PLLs to make this clock
- Using the external 125 MHz clock reference (instead of internal) to make the clocking identical between linkNode and appNode in MPS's 125MHz, 156.25MHz and 625 MHz clock generation. 