### PR TITLE
Release Candidate v5.3.0

### DIFF
--- a/.github/workflows/amc_ci.yml
+++ b/.github/workflows/amc_ci.yml
@@ -20,7 +20,7 @@ jobs:
 
   test_and_document:
     name: Test And Generate Documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
 
       # This step checks out a copy of your repository.
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install dependencies
         run: |
@@ -38,6 +38,13 @@ jobs:
           sudo apt-get install doxygen doxygen-doc doxygen-latex doxygen-gui graphviz ghdl
           python -m pip install --upgrade pip
           pip install flake8
+
+      - name: Check for trailing whitespace
+        run: |
+          if grep -rnI '[[:blank:]]$' --include=\*.{vhd,v,tcl,py,yaml,xdc} .; then
+            echo "Error: Trailing whitespace found in the repository!"
+            exit 1
+          fi
 
       - name: VHDL Syntax Check
         run: |

--- a/AmcCarrierCore/core/AmcCarrierPkg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierPkg.vhd
@@ -25,8 +25,8 @@ use lcls_timing_core.TimingPkg.all;
 
 package AmcCarrierPkg is
 
-   -- https://github.com/slaclab/amc-carrier-core/releases/tag/v5.2.0
-   constant AMC_CARRIER_CORE_VERSION_C : slv(31 downto 0) := x"05_02_00_00";
+   -- https://github.com/slaclab/amc-carrier-core/releases/tag/v5.3.0
+   constant AMC_CARRIER_CORE_VERSION_C : slv(31 downto 0) := x"05_03_00_00";
 
    -----------------------------------------------------------
    -- Application: Configurations, Constants and Records Types

--- a/AmcCarrierCore/core/kintexuplus/AmcCarrierEth.vhd
+++ b/AmcCarrierCore/core/kintexuplus/AmcCarrierEth.vhd
@@ -36,6 +36,8 @@ entity AmcCarrierEth is
       DEBUG_PATH_SELECT_G   : boolean  := false;  -- false = UDP[port=8193], true = UDP[port=8194]
       ETH_USR_FRAME_LIMIT_G : positive := 4096);  -- 4kB
    port (
+      gtRefClk              : out sl;
+      gtRefClkBufg          : out sl;
       -- Local Configuration and status
       localMac              : in  slv(47 downto 0);  --  big-Endian configuration
       localIp               : in  slv(31 downto 0);  --  big-Endian configuration
@@ -200,6 +202,8 @@ begin
             -- AXI Streaming Configurations
             AXIS_CONFIG_G => EMAC_AXIS_CONFIG_C)
          port map (
+            gtClkOut       => gtRefClk,
+            phyClk         => gtRefClkBufg,
             -- Local Configurations
             localMac       => localMac,
             -- Streaming DMA Interface
@@ -247,6 +251,8 @@ begin
             -- AXI Streaming Configurations
             AXIS_CONFIG_G      => (others => EMAC_AXIS_CONFIG_C))
          port map (
+            gtClkOut        => gtRefClk,
+            refClkOut       => gtRefClkBufg,
             -- Local Configurations
             localMac(0)     => localMac,
             -- Streaming DMA Interface

--- a/AmcCarrierCore/fsbl/AmcCarrierCoreFsbl.vhd
+++ b/AmcCarrierCore/fsbl/AmcCarrierCoreFsbl.vhd
@@ -214,6 +214,10 @@ architecture mapping of AmcCarrierCoreFsbl is
 
    signal ref156MHzClk  : sl;
    signal ref156MHzRst  : sl;
+
+   signal ref125MHzClk  : sl;
+   signal ref125MHzRst  : sl;
+
    signal bsiBus        : BsiBusType;
    signal timingBusIntf : TimingBusType;
 
@@ -345,6 +349,8 @@ begin
          -- Core Ports --
          ----------------
          -- Backplane MPS Ports
+         ref125MHzClk    => ref125MHzClk,
+         ref125MHzRst    => ref125MHzRst,
          mpsClkIn        => mpsClkIn,
          mpsClkOut       => mpsClkOut,
          mpsBusRxP       => mpsBusRxP,
@@ -402,6 +408,8 @@ begin
          recTimingRst         => recTimingRst,
          ref156MHzClk         => ref156MHzClk,
          ref156MHzRst         => ref156MHzRst,
+         ref125MHzClk         => ref125MHzClk,
+         ref125MHzRst         => ref125MHzRst,
          gthFabClk            => gthFabClk,
          ------------------------
          -- Core Ports to Wrapper

--- a/AmcCarrierCore/fsbl/AmcCarrierFsbl.vhd
+++ b/AmcCarrierCore/fsbl/AmcCarrierFsbl.vhd
@@ -79,6 +79,8 @@ entity AmcCarrierFsbl is
       recTimingRst         : out   sl;
       ref156MHzClk         : out   sl;
       ref156MHzRst         : out   sl;
+      ref125MHzClk         : out   sl;
+      ref125MHzRst         : out   sl;
       gthFabClk            : out   sl;
       ------------------------
       -- Core Ports to Wrapper
@@ -253,21 +255,24 @@ begin
          INPUT_BUFG_G      => true,
          FB_BUFG_G         => true,
          RST_IN_POLARITY_G => '1',
-         NUM_CLOCKS_G      => 1,
+         NUM_CLOCKS_G      => 2,
          -- MMCM attributes
          BANDWIDTH_G       => "OPTIMIZED",
          CLKIN_PERIOD_G    => 6.4,
          DIVCLK_DIVIDE_G   => 1,
          CLKFBOUT_MULT_G   => 8,
-         CLKOUT0_DIVIDE_G  => 8)
+         CLKOUT0_DIVIDE_G  => 8,
+         CLKOUT1_DIVIDE_G  => 10)
       port map(
          -- Clock Input
          clkIn     => fabClk,
          rstIn     => fabRst,
          -- Clock Outputs
          clkOut(0) => axilClk,
+         clkOut(1) => ref125MHzClk,
          -- Reset Outputs
-         rstOut(0) => reset);
+         rstOut(0) => reset,
+         rstOut(1) => ref125MHzRst);
 
    -- Forcing BUFG for reset that's used everywhere
    U_BUFG : BUFG

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCore.vhd
@@ -99,6 +99,8 @@ entity AmcCarrierCore is
       recTimingRst         : out   sl;
       ref156MHzClk         : out   sl;
       ref156MHzRst         : out   sl;
+      ref125MHzClk         : out   sl;
+      ref125MHzRst         : out   sl;
       stableClk            : out   sl;
       stableRst            : out   sl;
       gthFabClk            : out   sl;
@@ -285,21 +287,24 @@ begin
          INPUT_BUFG_G      => true,
          FB_BUFG_G         => true,
          RST_IN_POLARITY_G => '1',
-         NUM_CLOCKS_G      => 1,
+         NUM_CLOCKS_G      => 2,
          -- MMCM attributes
          BANDWIDTH_G       => "OPTIMIZED",
          CLKIN_PERIOD_G    => 12.8,     -- 78.125MHz
          DIVCLK_DIVIDE_G   => 1,        -- 78.125MHz = 78.125MHz/1
          CLKFBOUT_MULT_G   => 16,       -- 1.25GHz=78.125MHz*16
-         CLKOUT0_DIVIDE_G  => 8)        -- 156.25MHz=1.25GHz/8
+         CLKOUT0_DIVIDE_G  => 8,        -- 156.25MHz=1.25GHz/8
+         CLKOUT1_DIVIDE_G  => 10)       -- 125MHz=1.25GHz/10
       port map(
          -- Clock Input
          clkIn     => fabClk,
          rstIn     => fabRst,
          -- Clock Outputs
          clkOut(0) => axilClk,
+         clkOut(1) => ref125MHzClk,
          -- Reset Outputs
-         rstOut(0) => reset);
+         rstOut(0) => reset,
+         rstOut(1) => ref125MHzRst);
 
    -- Help with meeting timing on the reset path
    U_Rst : entity surf.RstPipeline

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCoreAdv.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCoreAdv.vhd
@@ -241,6 +241,10 @@ architecture mapping of AmcCarrierCoreAdv is
 
    signal ref156MHzClk  : sl;
    signal ref156MHzRst  : sl;
+
+   signal ref125MHzClk  : sl;
+   signal ref125MHzRst  : sl;
+
    signal bsiBus        : BsiBusType;
    signal timingBusIntf : TimingBusType;
 
@@ -384,6 +388,8 @@ begin
             -- Core Ports --
             ----------------
             -- Backplane MPS Ports
+            ref125MHzClk    => ref125MHzClk,
+            ref125MHzRst    => ref125MHzRst,
             mpsClkIn        => mpsClkIn,
             mpsClkOut       => mpsClkOut,
             mpsBusRxP       => mpsBusRxP,
@@ -473,6 +479,8 @@ begin
          recTimingRst         => recTimingRst,
          ref156MHzClk         => ref156MHzClk,
          ref156MHzRst         => ref156MHzRst,
+         ref125MHzClk         => ref125MHzClk,
+         ref125MHzRst         => ref125MHzRst,
          gthFabClk            => gthFabClk,
          stableClk            => stableClk,
          stableRst            => stableRst,

--- a/AmcCarrierCore/non-fsbl/AmcCarrierCoreBase.vhd
+++ b/AmcCarrierCore/non-fsbl/AmcCarrierCoreBase.vhd
@@ -241,6 +241,10 @@ architecture mapping of AmcCarrierCoreBase is
 
    signal ref156MHzClk  : sl;
    signal ref156MHzRst  : sl;
+
+   signal ref125MHzClk  : sl;
+   signal ref125MHzRst  : sl;
+
    signal bsiBus        : BsiBusType;
    signal timingBusIntf : TimingBusType;
 
@@ -384,6 +388,8 @@ begin
             -- Core Ports --
             ----------------
             -- Backplane MPS Ports
+            ref125MHzClk    => ref125MHzClk,
+            ref125MHzRst    => ref125MHzRst,
             mpsClkIn        => mpsClkIn,
             mpsClkOut       => mpsClkOut,
             mpsBusRxP       => mpsBusRxP,
@@ -473,6 +479,8 @@ begin
          recTimingRst         => recTimingRst,
          ref156MHzClk         => ref156MHzClk,
          ref156MHzRst         => ref156MHzRst,
+         ref125MHzClk         => ref125MHzClk,
+         ref125MHzRst         => ref125MHzRst,
          gthFabClk            => gthFabClk,
          stableClk            => stableClk,
          stableRst            => stableRst,

--- a/AppMps/rtl/AppMps.vhd
+++ b/AppMps/rtl/AppMps.vhd
@@ -73,6 +73,8 @@ entity AppMps is
       -- Core Ports --
       ----------------
       -- Backplane MPS Ports
+      ref125MHzClk    : in  sl;
+      ref125MHzRst    : in  sl;
       mpsClkIn        : in  sl;
       mpsClkOut       : out sl;
       mpsBusRxP       : in  slv(14 downto 1);
@@ -150,6 +152,8 @@ begin
          -- Core Ports --
          ----------------
          -- Backplane MPS Ports
+         ref125MHzClk => ref125MHzClk,
+         ref125MHzRst => ref125MHzRst,
          mpsClkIn     => mpsClkIn,
          mpsClkOut    => mpsClkOut);
 

--- a/BsaCore/ruckus.tcl
+++ b/BsaCore/ruckus.tcl
@@ -8,11 +8,10 @@ loadSource -lib amc_carrier_core -dir  "$::DIR_PATH/rtl/"
 # Get the family type
 set family [getFpgaFamily]
 
-if { ${family} == "kintexuplus" } {
-   loadSource -path "$::DIR_PATH/cores/BsaAxiInterconnect/xilinxUltraScale/BsaAxiInterconnect.dcp"
-}
 
-if { ${family} == "kintexu" } {
+if { ${family} eq {kintexu} ||
+     ${family} eq {kintexuplus} ||
+     ${family} eq {zynquplusRFSOC} } {
    loadSource -path "$::DIR_PATH/cores/BsaAxiInterconnect/xilinxUltraScale/BsaAxiInterconnect.dcp"
 }
 

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -9,8 +9,8 @@ if { [VersionCheck 2018.3 ] < 0 } {
 # Check for submodule tagging
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
    if { [SubmoduleCheck {lcls-timing-core} {3.10.0} "mustBeExact" ] < 0 } {exit -1}
-   if { [SubmoduleCheck {ruckus}           {4.17.2} "mustBeExact" ] < 0 } {exit -1}
-   if { [SubmoduleCheck {surf}             {2.53.0} "mustBeExact" ] < 0 } {exit -1}
+   if { [SubmoduleCheck {ruckus}           {4.17.4} "mustBeExact" ] < 0 } {exit -1}
+   if { [SubmoduleCheck {surf}             {2.54.0} "mustBeExact" ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"
    puts "OVERRIDE_SUBMODULE_LOCKS != 0"


### PR DESCRIPTION
### Description
- [reorg of the ref125MHzClk used for linkNode and appNode](https://github.com/slaclab/amc-carrier-core/commit/566ee92cd64eae18a38ace954a22006f5a8c3c77)
- [adding optional output ports required for RFMC carrier](https://github.com/slaclab/amc-carrier-core/commit/05ad7290e00bc8c625543275ae785acbdae05453)
- [adding zynquplusRFSOC support to BSA ruckus.tcl](https://github.com/slaclab/amc-carrier-core/commit/4189f6a4005b124e7f17f3409d1d9ea18c7f14ee)
- [migrating CI from ubuntu-20.04 to ubuntu-24.04](https://github.com/slaclab/amc-carrier-core/commit/8b5e1befcacde6cf06af945dde2374bfe686e7a6)