### PR TITLE
fix(RtmCryoDet.dacLut): Use array variable for MemArray.

### DIFF
--- a/.github/workflows/amc_ci.yml
+++ b/.github/workflows/amc_ci.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
 
       # This step checks out a copy of your repository.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.12
 

--- a/python/AmcCarrierCore/AppHardware/RtmCryoDet/_dacLut.py
+++ b/python/AmcCarrierCore/AppHardware/RtmCryoDet/_dacLut.py
@@ -28,42 +28,19 @@ class LutMem(pr.Device):
 
         super().__init__(name=name,description=description,**kwargs)
 
-        self.addRemoteVariables(
-            name        = 'MEM',
-            offset      = 0x0,
-            number      =  2**ADDR_WIDTH_G,
-            bitSize     =  20,
-            bitOffset   =  0,
-            stride      =  4,
-            mode        = "RW",
-            base         = pr.Int,
-            hidden      = True,
-        )
-
-        self.add(pr.LinkVariable(
+        self.add(pr.RemoteVariable(
             name         = 'MemArray',
             hidden       = True,
             description  = "LUT mem array",
-            dependencies = [self.node(f'MEM[{i}]') for i in range(2**ADDR_WIDTH_G)],
-            linkedGet    = lambda dev, var, read: dev.getArray(dev, var, read),
-            linkedSet    = lambda dev, var, value: dev.setArray(dev, var, value),
-            typeStr      = "List[Int20]",
+            offset       = 0x0,
+            numValues    = 2**ADDR_WIDTH_G,
+            valueBits    = 20,
+            valueStride  = 32,
+            bitOffset    = 0,
+            base         = pr.Int,
+            mode         = "RW",
+            verify       = False,
         ))
-
-    @staticmethod
-    def setArray(dev, var, value):
-        for variable, setpoint in zip(var.dependencies, value):
-            variable.set(setpoint, write=False)
-        dev.writeBlocks()
-        dev.verifyBlocks()
-        dev.checkBlocks()
-
-    @staticmethod
-    def getArray(dev, var, read):
-        if read:
-            dev.readBlocks(variable=var.dependencies)
-            dev.checkBlocks(variable=var.dependencies)
-        return [variable.value() for variable in var.dependencies]
 
 
 class LutCtrl(pr.Device):


### PR DESCRIPTION
Without this, an enormous number of updates are added to the root updateQueue when the array is read/written.

I confirmed that this not break any access of these registers in `cryo-det` or `pysmurf`.

This fixes the observed issues in the `sodetlib` `take_bias_steps` routine. We should probably audit this code to see if there are other similarly problematic patterns.