### PR TITLE
Updating to latest lcls-timing-core (v3.10.7)

### DIFF
--- a/AmcCarrierCore/core/AmcCarrierPkg.vhd
+++ b/AmcCarrierCore/core/AmcCarrierPkg.vhd
@@ -25,8 +25,8 @@ use lcls_timing_core.TimingPkg.all;
 
 package AmcCarrierPkg is
 
-   -- https://github.com/slaclab/amc-carrier-core/releases/tag/v5.3.4
-   constant AMC_CARRIER_CORE_VERSION_C : slv(31 downto 0) := x"05_03_04_00";
+   -- https://github.com/slaclab/amc-carrier-core/releases/tag/v5.4.0
+   constant AMC_CARRIER_CORE_VERSION_C : slv(31 downto 0) := x"05_04_00_00";
 
    -----------------------------------------------------------
    -- Application: Configurations, Constants and Records Types

--- a/AmcCarrierCore/core/kintexu/AmcCarrierEth.vhd
+++ b/AmcCarrierCore/core/kintexu/AmcCarrierEth.vhd
@@ -380,10 +380,9 @@ begin
 
       U_RssiServer : entity amc_carrier_core.AmcCarrierRssi
          generic map (
-            TPD_G                 => TPD_G,
-            ETH_USR_FRAME_LIMIT_G => ETH_USR_FRAME_LIMIT_G,
-            DEBUG_PATH_SELECT_G   => DEBUG_PATH_SELECT_G,
-            AXI_BASE_ADDR_G       => AXI_CONFIG_C(AXI_RSSI_NONE_ILEAVE_INDEX_C).baseAddr)
+            TPD_G               => TPD_G,
+            DEBUG_PATH_SELECT_G => DEBUG_PATH_SELECT_G,
+            AXI_BASE_ADDR_G     => AXI_CONFIG_C(AXI_RSSI_NONE_ILEAVE_INDEX_C).baseAddr)
          port map (
             -- Slave AXI-Lite Interface
             axilClk            => axilClk,
@@ -434,9 +433,8 @@ begin
 
       U_RssiServer : entity amc_carrier_core.AmcCarrierRssiInterleave
          generic map (
-            TPD_G                 => TPD_G,
-            ETH_USR_FRAME_LIMIT_G => ETH_USR_FRAME_LIMIT_G,
-            AXI_BASE_ADDR_G       => AXI_CONFIG_C(AXI_RSSI_ILEAVE_INDEX_C).baseAddr)
+            TPD_G           => TPD_G,
+            AXI_BASE_ADDR_G => AXI_CONFIG_C(AXI_RSSI_ILEAVE_INDEX_C).baseAddr)
          port map (
             -- Slave AXI-Lite Interface
             axilClk          => axilClk,

--- a/AppMps/rtl/AppMpsEncoder.vhd
+++ b/AppMps/rtl/AppMpsEncoder.vhd
@@ -191,7 +191,7 @@ begin
    ---------------------------------
    -- Thresholds
    ---------------------------------
-   comb : process (axilRst, mpsReg, mpsSelect, r, rstTripValue) is
+   comb : process (axilRst, diagnosticBus, mpsReg, mpsSelect, r, rstTripValue) is
       variable v       : RegType;
       variable chan    : integer;
       variable thold   : integer;

--- a/python/AmcCarrierCore/AppHardware/AmcGenericAdcDac/_AmcGenericAdcDacCore.py
+++ b/python/AmcCarrierCore/AppHardware/AmcGenericAdcDac/_AmcGenericAdcDacCore.py
@@ -69,6 +69,24 @@ class AmcGenericAdcDacCore(pr.Device):
         self.DBG.writeBlocks(force=force, recurse=recurse, variable=variable)
         self._root.waitBlocks(recurse=True)
 
+        # Pulse the LMK's physical RESET pin before the SPI soft reset.
+        #
+        # LMK.RESET is register 0x000 bit 7, which is write-only, so the
+        # read-modify-write cannot preserve the other bits of that register
+        # (notably 3WIREDIS at bit 4).  It also does not reliably recover a
+        # part that has ended up in a bad state: an LMK whose PLL2 has lost
+        # lock can survive any number of soft resets and register reloads,
+        # which then presents downstream as a non-constant SysRef period and
+        # an AppTop.Init() that exhausts all of its JESD retries.
+        #
+        # The hardware pin returns the part to power-on defaults for real, so
+        # the register load below always starts from a known state.
+        self.DBG.LmkRst.set(0x1)
+        self._root.waitBlocks(recurse=True)
+        self.DBG.LmkRst.set(0x0)
+        self._root.waitBlocks(recurse=True)
+        time.sleep(0.100)
+
         self.LMK.RESET.set(0x1)
         self.LMK.RESET.set(0x0)
 

--- a/python/AmcCarrierCore/AppHardware/AmcGenericAdcDac/_AmcGenericAdcDacCore.py
+++ b/python/AmcCarrierCore/AppHardware/AmcGenericAdcDac/_AmcGenericAdcDacCore.py
@@ -40,6 +40,16 @@ class AmcGenericAdcDacCore(pr.Device):
 
         @self.command(description="Initialization for AMC card's JESD modules",)
         def InitAmcCard():
+            # Note: LMK.Init() is a SYNC, not a re-initialisation. It toggles
+            # register 0x143 and nothing else, so AppTop.Init()'s retry loop
+            # cannot recover an LMK whose clock has actually dropped out.
+            #
+            # Adding a hardware reset and register reload here was tried and
+            # is a regression: bring-up went from 8/9 to 0/8, failing in under
+            # 4 s with an SPI verify error inside LMK.Init(), with or without a
+            # longer settle after the reset. The reset in writeBlocks() runs
+            # once before the retry loop and is safe; doing it per retry is
+            # not. Do not re-add it without measuring.
             self.LMK.Init()
             time.sleep(1.000)
             for i in range(2):

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -8,8 +8,8 @@ if { [VersionCheck 2018.3 ] < 0 } {
 
 # Check for submodule tagging
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
-   if { [SubmoduleCheck {lcls-timing-core} {3.10.0} "mustBeExact" ] < 0 } {exit -1}
-   if { [SubmoduleCheck {ruckus}           {4.18.0} "mustBeExact" ] < 0 } {exit -1}
+   if { [SubmoduleCheck {lcls-timing-core} {3.10.7} "mustBeExact" ] < 0 } {exit -1}
+   if { [SubmoduleCheck {ruckus}           {4.30.0} "mustBeExact" ] < 0 } {exit -1}
    if { [SubmoduleCheck {surf}             {2.54.0} "mustBeExact" ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"


### PR DESCRIPTION
### Description
- [minor bug fix](https://github.com/slaclab/amc-carrier-core/commit/83148981e134474e22e4d74c0491f321c1ed50b0)
- [updating to the latest lcls-timing-core tag release](https://github.com/slaclab/amc-carrier-core/commit/1a347fab5a44e89f7ee97f43418346ca4aa79e50)
- [release prep](https://github.com/slaclab/amc-carrier-core/commit/3da15dea3eb00716f181c9d2d437c90d2d863d22)
- [bug fix: [Synth 8-614] signal 'diagnosticBus' is read in the process but is not in the sensitivity list](https://github.com/slaclab/amc-carrier-core/pull/426/commits/4e110056c10296b60bb5e125b4368fe5bf04529e)