### PR TITLE
fix(AmcGenericAdcDac): pulse the LMK hardware reset before programming

### DIFF
--- a/python/AmcCarrierCore/AppHardware/AmcGenericAdcDac/_AmcGenericAdcDacCore.py
+++ b/python/AmcCarrierCore/AppHardware/AmcGenericAdcDac/_AmcGenericAdcDacCore.py
@@ -69,6 +69,24 @@ class AmcGenericAdcDacCore(pr.Device):
         self.DBG.writeBlocks(force=force, recurse=recurse, variable=variable)
         self._root.waitBlocks(recurse=True)
 
+        # Pulse the LMK's physical RESET pin before the SPI soft reset.
+        #
+        # LMK.RESET is register 0x000 bit 7, which is write-only, so the
+        # read-modify-write cannot preserve the other bits of that register
+        # (notably 3WIREDIS at bit 4).  It also does not reliably recover a
+        # part that has ended up in a bad state: an LMK whose PLL2 has lost
+        # lock can survive any number of soft resets and register reloads,
+        # which then presents downstream as a non-constant SysRef period and
+        # an AppTop.Init() that exhausts all of its JESD retries.
+        #
+        # The hardware pin returns the part to power-on defaults for real, so
+        # the register load below always starts from a known state.
+        self.DBG.LmkRst.set(0x1)
+        self._root.waitBlocks(recurse=True)
+        self.DBG.LmkRst.set(0x0)
+        self._root.waitBlocks(recurse=True)
+        time.sleep(0.100)
+
         self.LMK.RESET.set(0x1)
         self.LMK.RESET.set(0x0)
 

--- a/python/AmcCarrierCore/AppHardware/AmcGenericAdcDac/_AmcGenericAdcDacCore.py
+++ b/python/AmcCarrierCore/AppHardware/AmcGenericAdcDac/_AmcGenericAdcDacCore.py
@@ -40,6 +40,16 @@ class AmcGenericAdcDacCore(pr.Device):
 
         @self.command(description="Initialization for AMC card's JESD modules",)
         def InitAmcCard():
+            # Note: LMK.Init() is a SYNC, not a re-initialisation. It toggles
+            # register 0x143 and nothing else, so AppTop.Init()'s retry loop
+            # cannot recover an LMK whose clock has actually dropped out.
+            #
+            # Adding a hardware reset and register reload here was tried and
+            # is a regression: bring-up went from 8/9 to 0/8, failing in under
+            # 4 s with an SPI verify error inside LMK.Init(), with or without a
+            # longer settle after the reset. The reset in writeBlocks() runs
+            # once before the retry loop and is safe; doing it per retry is
+            # not. Do not re-add it without measuring.
             self.LMK.Init()
             time.sleep(1.000)
             for i in range(2):


### PR DESCRIPTION
## Problem

`AmcGenericAdcDacCore.writeBlocks()` reset the LMK04828 only through `LMK.RESET`, the SPI soft reset at register `0x000` bit 7. Two problems with that:

1. The register is write-only, so the read-modify-write cannot preserve its other bits, notably `3WIREDIS` at bit 4.
2. More importantly, it does not reliably recover a part that has ended up in a bad state. An LMK whose PLL2 has lost lock survives any number of soft resets and full register reloads.

Downstream that presents as a non-constant SysRef period (`SysRefPeriodmin != SysRefPeriodmax`), which fails the check in `AppTop.Init()` and burns all eight JESD retries:

```
AppTop.Init().AppTopJesd[0].JesdTx: Link Not Locked: SysRefPeriodmin = 1, SysRefPeriodmax = 971
AppTop.Init().AppTopJesd[0].JesdRx: Link Not Locked: PositionErr = 15, AlignErr = 15
Re-executing AppTop.Init(): retryCnt = 1
...
AppTop.Init(): Too many retries and giving up on retries
```

## Change

Pulse `DBG.LmkRst`, the LMK's physical RESET pin, before the existing soft reset, so the register load always starts from power-on defaults.

## Measurement

On an AMC carrier with AmcGenericAdcDac in bay 0, over nine bring-ups:

| | |
|---|---|
| Before | consistently exhausted all eight retries |
| After | `AppTop.Init()` passed 8/9 |

A later run of eight bring-ups gave 6/8 with constant SysRef and 0/8 hard failures.

## Caveats

Please read these before merging.

**This is a mitigation, not a cure.** SysRef was still observed jittering after a passing `Init()` in some runs (`14/15`, and once `1/5370`), so the underlying clocking instability on that setup is unresolved. It clears one failure mode: an LMK wedged such that no soft reset or register reload recovers it.

**It makes `JesdHealth()` slightly easier to pass.** The check samples `SysRefPeriodmin/max` at one instant just after `CmdClearErrors`. In one run it passed and SysRef read `1/6059` a second later. A marginal link that passes will misalign samples silently, so this trades a loud failure for a quiet one in that corner.

## Second commit

`e9385d7a` adds no functional change, only a comment recording a measured negative result so it is not rediscovered.

`AppTop.Init()` calls `InitAmcCard()` on every retry, and that only calls `LMK.Init()`, which is a SYNC: it toggles register `0x143` and nothing else. So the retry loop structurally cannot recover a bad LMK. Moving the hardware reset there looks like the obvious follow-up fix and is a clear regression:

| Variant | Result |
|---|---|
| Unchanged | 6-8 of 8 bring-ups locked, 0 hard failures |
| Reset + reload per retry | 0 of 8, failing in under 4 s with an SPI verify error inside `LMK.Init()` |
| Same, with a 0.5 s settle after reset | 0 of 3, identically |

The reset in `writeBlocks()` runs once before the retry loop and is safe. Doing it per retry is not.